### PR TITLE
Nom du Lunaire

### DIFF
--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -598,13 +598,13 @@
   },
   {
     "id": "moonchild",
-    "name": "Lunaire",
+    "name": "Enfant de la lune",
     "edition": "bmr",
     "team": "outsider",
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 49,
-    "otherNightReminder": "Si le Lunaire a désigné un joueur et que ce joueur est bon: le joueur désigné meurt.",
+    "otherNightReminder": "Si l'Enfant de la lune a désigné un joueur et que ce joueur est bon: le joueur désigné meurt.",
     "reminders": [
       "Mort"
     ],


### PR DESCRIPTION
Correction du "Lunaire" en "Enfant de la lune", qui est une bien meilleure traduction. Je précise que ce nom est assez court pour rentrer dans la case sur le site. À voir si ça risque de gêner les joueurs (pour une question d'habitude j'entends)...