### PR TITLE
Updating Mezepheles' French Description

### DIFF
--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1780,7 +1780,7 @@
       "Épuisé"
     ],
     "setup": false,
-    "ability": "Vous commencez la partie en connaissant un mot secret. La première fois qu'un Bon joueur prononce ce mot en présence du Narrateur, il devient Mauvais la nuit suivante, sans changer de rôle."
+    "ability": "Vous commencez la partie en connaissant un mot secret. La première fois qu'un Bon joueur prononce ce mot en présence du Narrateur, il devient Mauvais durant la nuit, sans changer de rôle."
   },
   {
     "id": "marionette",


### PR DESCRIPTION
If a good player pronounces the secret word during the night, and if he pronounces it before Mezepheles' effect in night order, then he becomes evil that night, and not the next one.