### PR TITLE
Correcting Mutant's french description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+### Version 3.10.2
+- Some corrections in the French version
+- Changing default vote duration (3s -> 1s)
+
+---
+
 ### Version 3.10.1
 Correct some french descriptions (Magician, Acrobat, Riot, Legion, Pixie)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 ======
 
+### Version 3.11.2
+- Some corrections in the French version
+- Changing default vote duration (3s -> 1s)
+
+---
+
+### Version 3.11.1
+Small UI tweeks to custom scripts selection
+
+======
+
+### Version 3.11.0
+Add several included custom scripts
+
 ---
 
 ### Version 3.10.2
-- Some corrections in the French version
-- Changing default vote duration (3s -> 1s)
+Corrected french description for Minstrel
 
 ---
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1036,7 +1036,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous êtes persuadé de ne pas être un Étranger. Si vous n'êtes pas suffisamment convaincant, vous pouvez être exécuté."
+    "ability": "Si vous êtes persuadé d’être un Étranger, vous pouvez être exécuté."
   },
   {
     "id": "sweetheart",

--- a/src/store/modules/session.js
+++ b/src/store/modules/session.js
@@ -24,7 +24,7 @@ const state = () => ({
   nomination: false,
   votes: [],
   lockedVote: 0,
-  votingSpeed: 1000,
+  votingSpeed: 3000,
   isVoteInProgress: false,
   voteHistory: [],
   markedPlayer: -1,

--- a/src/store/modules/session.js
+++ b/src/store/modules/session.js
@@ -24,7 +24,7 @@ const state = () => ({
   nomination: false,
   votes: [],
   lockedVote: 0,
-  votingSpeed: 3000,
+  votingSpeed: 1000,
   isVoteInProgress: false,
   voteHistory: [],
   markedPlayer: -1,


### PR DESCRIPTION
Correspond plus à la description originale. De plus, l'Almanach donne des précisions sur la persuasion, et cette formulation change tout. Si le Mutant était "persuadé de ne pas être Étranger", il devrait clairement dire avoir un autre rôle. Mais, comme il doit juste éviter d'être "persuadé d'être Étranger", il peut aussi sauver sa peau en ne parlant jamais de son rôle.