### PR TITLE
Correcting Mutant's french description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ======
 
-### Version 3.11.3
-Changing default vote duration (3s -> 1s)
+### Version 3.11.2
+Various corrections in the french version
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ======
 
+### Version 3.11.4
+Correcting the print of new scripts' names
+
+---
+
 ### Version 3.11.1
 Small UI tweeks to custom scripts selection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ======
 
-### Version 3.11.4
-Correcting the print of new scripts' names
+### Version 3.11.3
+Changing default vote duration (3s -> 1s)
 
 ---
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1036,7 +1036,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous êtes persuadé de ne pas être un Étranger. Si vous n'êtes pas suffisamment convaincant, vous pouvez être exécuté."
+    "ability": "Si vous êtes persuadé d’être un Étranger, vous pouvez être exécuté."
   },
   {
     "id": "sweetheart",


### PR DESCRIPTION
Correspond plus à la description VO.
De plus, l'Almanach montre bien qu'il y a une différence entre "ne pas être persuadé que X est vrai" et "être persuadé que X est faux".
Concrètement, et contrairement à ce que disait la précédente description VF, le Mutant n'est pas obligé de mentir sur son rôle : il peut aussi ne rien en dire.