### PR TITLE
Changing default value of "night"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ======
 
+### Version 3.11.8
+Changing value of day/night (night by default)
+
+---
+
 ### Version 3.11.4
 Correcting the print of new scripts' names
 
-=======
+---
 
 ### Version 3.11.3
 Changing default vote duration (3s -> 1s)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -102,7 +102,7 @@ export default new Vuex.Store({
   },
   state: {
     grimoire: {
-      isNight: false,
+      isNight: true,
       isNightOrder: true,
       isRinging: false,
       isPublic: true,


### PR DESCRIPTION
Vu que la partie commence toujours par une nuit. Plus pratique pour les Narrateurs qui, comme moi, vident le cache quand ils ferment leur navigateur internet.