### PR TITLE
Different default value of "isNightOrder" for the Story Teller and for the players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ======
 
-### Version 3.11.9
+### Version
 Night order option automatically changed:
 - Automatically printed by default for the Story Teller
 - Automatically unprinted by default for players

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ======
 
-### Version 3.11.8
-Changing value of day/night (night by default)
+### Version 3.11.9
+Changing value of night order (unprinted by default)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ======
 
 ### Version 3.11.9
-Changing value of night order (unprinted by default)
+Night order option automatically changed:
+- Automatically printed by default for the Story Teller
+- Automatically unprinted by default for players
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ======
 
+### Version 3.11.8
+Changing value of day/night (night by default)
+
+---
+
 ### Version 3.11.4
 Correcting the print of new scripts' names
 
-=======
+---
 
 ### Version 3.11.3
 Changing default vote duration (3s -> 1s)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -102,7 +102,7 @@ export default new Vuex.Store({
   },
   state: {
     grimoire: {
-      isNight: false,
+      isNight: true,
       isNightOrder: true,
       isRinging: false,
       isPublic: true,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -102,8 +102,8 @@ export default new Vuex.Store({
   },
   state: {
     grimoire: {
-      isNight: true,
-      isNightOrder: true,
+      isNight: false,
+      isNightOrder: false,
       isRinging: false,
       isPublic: true,
       isMenuOpen: false,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -103,7 +103,7 @@ export default new Vuex.Store({
   state: {
     grimoire: {
       isNight: false,
-      isNightOrder: false,
+      isNightOrder: true,
       isRinging: false,
       isPublic: true,
       isMenuOpen: false,

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -637,7 +637,7 @@ class LiveSession {
     const players = this._store.state.players.players;
     if (players.length > seat && (seat < 0 || !players[seat].id)) {
       this._send("claim", [seat, this._store.state.session.playerId]);
-	    this._store.state.grimoire.isNightOrder = false ;
+      this._store.state.grimoire.isNightOrder = false ;
     }
   }
 

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -637,7 +637,7 @@ class LiveSession {
     const players = this._store.state.players.players;
     if (players.length > seat && (seat < 0 || !players[seat].id)) {
       this._send("claim", [seat, this._store.state.session.playerId]);
-      this._store.state.grimoire.isNightOrder = false ;
+      this._store.state.grimoire.isNightOrder = false;
     }
   }
 

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -637,6 +637,7 @@ class LiveSession {
     const players = this._store.state.players.players;
     if (players.length > seat && (seat < 0 || !players[seat].id)) {
       this._send("claim", [seat, this._store.state.session.playerId]);
+	    this._store.state.grimoire.isNightOrder = false ;
     }
   }
 


### PR DESCRIPTION
Permet de cocher automatiquement l'option "Ordre nocturne" pour les Narrateurs, et de la décocher pour les joueurs.
Il n'y a qu'un seul cas où cela ne fonctionne pas : celui ou le Narrateur était joueur lors de sa dernière partie, et qu'il n'a pas vidé le cache entretemps.
Dans tous les cas, il est toujours possible de changer manuellement cette variable en (dé)cochant une case dans le menu.