### PR TITLE
Order default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ======
+
 Changing the default value of "isNightOrder"
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ======
-### Unreleased changes
+Changing the default value of "isNightOrder"
 
 ---
 ### Version 3.12.0

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -103,7 +103,7 @@ export default new Vuex.Store({
   state: {
     grimoire: {
       isNight: false,
-      isNightOrder: true,
+      isNightOrder: false,
       isRinging: false,
       isPublic: true,
       isMenuOpen: false,


### PR DESCRIPTION
Si ça te semble problématique de changer à chaque fois (et ça se défend parfaitement), je pense qu'il vaut mieux en changer la valeur par défaut. Pour la plupart des joueurs, ça ne va rien changer (une fois qu'ils auront fait leur choix, c'est bon).
Pour les joueurs qui jouent pour la première fois en revanche, ça leur fait un truc de moins à comprendre (pas besoin de savoir ce que veulent dire ces nombres).