### PR TITLE
Correction de CHANGEMOD.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 
 ---
 ### Version 3.12.0
-Printing the number of alive non-Travellers
-Adding the picture leaf-top6.png
-Some corrections in the jinxes (in French)
-Correcting Atheist's french description
+- Printing the number of alive non-Travellers
+- Adding the picture leaf-top6.png
+- Some corrections in the jinxes (in French)
+- Correcting Atheist's french description
 
 ---
 


### PR DESCRIPTION
Sans ces tirets, lors de l'affichage, tous ces éléments sont sur la même ligne, rendant le document moins lisible