### PR TITLE
Legion's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1890,7 +1890,7 @@
     "otherNightReminder": "Vous pouvez choisir un joueur, Ce joueur meurt.",
     "reminders": [
       "Mort",
-      "Mourant"
+      "Condamné"
     ],
     "setup": true,
     "ability": "Chaque nuit*, un joueur peut mourir. Les exécutions ratent si seuls des joueurs Mauvais ont voté. Vous apparaissez également comme un Serviteur. [La majorité des joueurs sont Légion]"


### PR DESCRIPTION
En VO, "About to die" désigne spécifiquement un joueur qui a reçu assez de votes, et qui risque d'être exécuté. Ce jeton sert si on ne veut pas révéler au fur et à mesure quelles accusations passent, et qu'on veut garder le mystère jusqu'à la fin (un peu comme avec l'Organiste).