### PR TITLE
Evil twin's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -991,7 +991,8 @@
     "firstNightReminder": "Wake the Evil Twin and their twin. Confirm that they have acknowledged each other. Point to the Evil Twin. Show their Evil Twin token to the twin player. Point to the twin. Show their character token to the Evil Twin player.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Twin"],
+    "reminders": [],
+    "remindersGlobal": ["Twin"],
     "setup": false,
     "ability": "You & an opposing player know each other. If the good player is executed, evil wins. Good can't win if you both live."
   },

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1090,7 +1090,8 @@
     "firstNightReminder": "Réveillez le Jumeau Maléfique et son Jumeau. Informez-les tous deux du rôle de l'autre.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [
+    "reminders": [],
+    "remindersGlobal": [
       "Jumeau"
     ],
     "setup": false,


### PR DESCRIPTION
Plus pratique, d'une part pour le jumeau bénéfique qui voudrait noter qui est son jumeau, d'autre part pour les joueurs quand les deux jumeaux se révèlent.