### PR TITLE
Revolutionnary's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/en/fabled.json
+++ b/src/store/locale/en/fabled.json
@@ -43,7 +43,7 @@
     "id": "revolutionary",
     "firstNightReminder": "",
     "otherNightReminder": "",
-    "reminders": ["Same alignment","Used"],
+    "reminders": ["Same alignment", "Used"],
     "setup": false,
     "name": "Revolutionary",
     "team": "fabled",

--- a/src/store/locale/en/fabled.json
+++ b/src/store/locale/en/fabled.json
@@ -43,7 +43,7 @@
     "id": "revolutionary",
     "firstNightReminder": "",
     "otherNightReminder": "",
-    "reminders": ["Used"],
+    "reminders": ["Same alignment","Used"],
     "setup": false,
     "name": "Revolutionary",
     "team": "fabled",

--- a/src/store/locale/fr/fabled.json
+++ b/src/store/locale/fr/fabled.json
@@ -43,7 +43,7 @@
     "id": "revolutionary",
     "firstNightReminder": "",
     "otherNightReminder": "",
-    "reminders": ["Utilisé"],
+    "reminders": ["Même camp", "Utilisé"],
     "setup": false,
     "name": "Révolutionnaire",
     "team": "fabled",


### PR DESCRIPTION
Officiellement, selon l'Almanach, il faudrait placer le jeton "Épuise" entre les deux joueurs, avant de le décaler sur l'un des deux quand nécessaire. Vu que ce n'est pas possible en ligne de placer un jeton entre deux joueurs, autant avoir une alternative pour noter ça si nécessaire.