### PR TITLE
Alchemist's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -1354,7 +1354,7 @@
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
-    "remindersGlobal": ["Is the Alchemist"],
+    "remindersGlobal": ["Alchemist"],
     "setup": false,
     "ability": "You have a not-in-play Minion ability."
   },

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1498,10 +1498,7 @@
     "otherNight": 0,
     "otherNightReminder": "Si la capacité de l'alchimiste s'utilise la nuit, réveillez le.",
     "reminders": [],
-    "remindersGlobal": [
-      "Alchimiste",
-      "Bon"
-    ],
+    "remindersGlobal": ["Alchimiste"],
     "setup": false,
     "ability": "Vous avez la capacité d'un Serviteur qui n'est pas en jeu."
   },


### PR DESCRIPTION
- Dans en/roles, simplification du jeton
- Dans fr/roles, suppression du jeton "Bon" (si tu notes que ce joueur est Alchimiste, c'est redondant de préciser aussi qu'il est bon, et au besoin les jetons par défaut peuvent être utilisés)

PS: S'il y a une raison que je ne vois pas d'utiliser le jeton "Bon", ça pourrait être utile, plutôt que de le supprimer, de le rajouter au contraire aussi dans en/roles