### PR TITLE
Lunatic's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -576,9 +576,8 @@
     "firstNightReminder": "If 7 or more players: Show the Lunatic a number of arbitrary 'Minions', players equal to the number of Minions in play. Show 3 character tokens of arbitrary good characters. If the token received by the Lunatic is a Demon that would wake tonight: Allow the Lunatic to do the Demon actions. Place their 'attack' markers. Wake the Demon. Show the Demon\u2019s real character token. Show them the Lunatic player. If the Lunatic attacked players: Show the real demon each marked player. Remove any Lunatic 'attack' markers.",
     "otherNight": 20,
     "otherNightReminder": "Allow the Lunatic to do the actions of the Demon. Place their 'attack' markers. If the Lunatic selected players: Wake the Demon. Show the 'attack' marker, then point to each marked player. Remove any Lunatic 'attack' markers.",
-    "reminders": ["Attack 1",
-        "Attack 2",
-        "Attack 3"],
+    "reminders": [],
+    "remindersGlobal": ["Lunatic"],
     "setup": false,
     "ability": "You think you are a Demon, but you are not. The Demon knows who you are & who you choose at night."
   },

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -635,7 +635,8 @@
     "firstNightReminder": "S'il y a 7 joueurs ou plus, indiquez à l'Aliéné un nombre de rôles de Serviteurs correspondant au nombre de Serviteurs en jeu et des joueurs pour chacuns de ces personnages. Montrez 3 jetons de personnages bons de votre choix. Si le faux personnage de Démon assigné à l'Aliéné a des actions de nuit, prétendez que vous lui faites réaliser ces actions. Placez le(s) marqueur(s) d'attaque de l'Aliéné. Réveillez le vrai Démon. Dévoilez au Démon les véritables Serviteurs et 3 bons personnages qui ne sont pas en jeu. Dévoilez au Démon qui est l'Aliéné. Si l'Aliéné a attaqué des joueurs, dévoilez au véritable Démon les joueurs marqués puis retirez les marqueurs de l'Aliéné.",
     "otherNight": 21,
     "otherNightReminder": "Permettez à l'Aliéné de réaliser les actions du Démon qu'il croit être. Placez le(s) marqueur(s) d'attaque. Si l'Aliéné a indiqué des joueurs, réveillez le Démon. Dévoilez au Démon les marqueurs de l'Aliéné puis retirez-les.",
-    "reminders": [
+    "reminders": [],
+    "remindersGlobal": [
       "Aliéné"
     ],
     "setup": true,


### PR DESCRIPTION
Plus pratique pour le Narrateur qui veut indiquer qui est Aliéné, de la même manière qu'avec l'Ivrogne ou la Marionnette.