### PR TITLE
Drunk's token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -213,7 +213,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "remindersGlobal": [
-      "Ivre"
+      "Ivrogne"
     ],
     "setup": true,
     "ability": "Vous ne savez pas que vous êtres l'Ivrogne. Vous croyez avoir un rôle de Villageois, mais vous ne l'avez pas."


### PR DESCRIPTION
Assez difficile de savoir ce que voulait dire la VO, vu que le même mot est utilisé pour "ivre" et pour "Ivrogne".
Cependant, l'exemple de l'Aliéné ou de la Marionnette me laisse penser qu'il s'agit bien du rôle.
De plus, ça m'est arrivé une ou deux fois d'avoir des Espions découvrant le jeton, et demandant "Comment il peut être ivre dans Trouble Brewing ?". Cette modification peut potentiellement rendre les choses plus claires.