### PR TITLE
Default value of "isNightOrder" for players and ST:   V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 
 
-### Version 3.13.1
-Some corrections in the reminders tokens:
-- Correcting some french names
-- Putting some tokens in "remindersGlobal"
-- Deleting some useless tokens, or adding some other
+### Version 3.13.2
+Night order option automatically changed:
+- Automatically printed by default for the Story Teller
+- Automatically unprinted by default for players
 
 ---
 ### Version 3.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 
 
+### Version 3.13.1
+Some corrections in the reminders tokens:
+- Correcting some french names
+- Putting some tokens in "remindersGlobal"
+- Deleting some useless tokens, or adding some other
+
 ---
-
 ### Version 3.13.0
-
 - Correcting the print when ST assigns roles (adding spaces)
 - Changing the default value of "isNightOrder"
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -309,6 +309,7 @@ export default {
         this.$store.commit("session/setSpectator", false);
         this.$store.commit("session/setSessionId", sessionId);
         this.$store.commit("toggleGrimoire", false);
+        this.$store.state.grimoire.isNightOrder = true;
         this.copySessionUrl();
       }
     },


### PR DESCRIPTION
Je pense que cette fois, il n'y a aucun problème.
Contrairement aux joueurs, pour qui c'est plus subjectif, la grande majorité des Narrateurs voudront afficher ce nombre, d'où l'intérêt de ce changement par défaut.
Il reste cependant bien sûr possible de modifier cette variable via le menu.
Comme la variable n'est modifiée que lorsque la session est créée, cela n'arrive qu'une fois par session de jeu. Donc, si le Narrateur change cette variable, puis a une micro-coupure de connexion, la variable ne reviendra pas à sa valeur par défaut.