### PR TITLE
Keeping Fabled while clearing roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Upcomming Version
+Correcting automatic adding/deletion of Fabled
 
 ### Version 3.17.0
 

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -86,7 +86,6 @@ const actions = {
         id,
         pronouns,
       }));
-      commit("setFabled", { fabled: [] });
     }
     commit("set", players);
     commit("setBluff");


### PR DESCRIPTION
Quand on sélectionne "Effacer rôles" via le menu, il n'y a a priori aucune raison pour que l'on souhaite également effacer les Fabuleux.