### PR TITLE
[OLD REQUEST] Bonus cases to take notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+- Adding four spaces to add some roles for notes
+
 ## Upcomming Version
 - Adding a missing jinx
 - Updating night order (and its print)

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -65,8 +65,8 @@
               class="night-order first"
               v-if="
                 notes[2 * (i - 1) + (j - 1)] &&
-                  nightOrder.get(notes[2 * (i - 1) + (j - 1)]).first &&
-                  (grimoire.isNightOrder || !session.isSpectator)
+                nightOrder.get(notes[2 * (i - 1) + (j - 1)]).first &&
+                (grimoire.isNightOrder || !session.isSpectator)
               "
             >
               <em>{{ nightOrder.get(notes[2 * (i - 1) + (j - 1)]).first }}.</em>
@@ -78,8 +78,8 @@
               class="night-order other"
               v-if="
                 notes[2 * (i - 1) + (j - 1)] &&
-                  nightOrder.get(notes[2 * (i - 1) + (j - 1)]).other &&
-                  (grimoire.isNightOrder || !session.isSpectator)
+                nightOrder.get(notes[2 * (i - 1) + (j - 1)]).other &&
+                (grimoire.isNightOrder || !session.isSpectator)
               "
             >
               <em>{{ nightOrder.get(notes[2 * (i - 1) + (j - 1)]).other }}.</em>
@@ -290,7 +290,7 @@ export default {
       this.isBluffsOpen = !this.isBluffsOpen;
       this.isNotesOpen = false;
     },
-	toggleNotes() {
+    toggleNotes() {
       this.isNotesOpen = !this.isNotesOpen;
     },
     toggleFabled() {

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -277,7 +277,7 @@ export default {
       nominate: -1,
       isBluffsOpen: true,
       isFabledOpen: true,
-	  isNotesOpen: false,
+      isNotesOpen: false,
       isTimeControlsOpen: false,
       timerName: "Timer",
       timerDuration: 1,
@@ -288,7 +288,7 @@ export default {
   methods: {
     toggleBluffs() {
       this.isBluffsOpen = !this.isBluffsOpen;
-	  this.isNotesOpen = false;
+      this.isNotesOpen = false;
     },
 	toggleNotes() {
       this.isNotesOpen = !this.isNotesOpen;

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -57,7 +57,7 @@
             :key="j"
             @click="
               openRoleModal(
-                (2 * (i - 1) + (j - 1)) * -1 - bluffSize[0] * bluffSize[1] - 1
+                (2 * (i - 1) + (j - 1)) * -1 - bluffSize[0] * bluffSize[1] - 1,
               )
             "
           >
@@ -269,7 +269,7 @@ export default {
   },
   data() {
     return {
-      selectedPlayer: 0,      
+      selectedPlayer: 0,
       bluffSize: [1, 3], // 1 row, 3 columns
       noteSize: [2, 2], // 2 rows, 2 columns
       swap: -1,

--- a/src/components/modals/RoleModal.vue
+++ b/src/components/modals/RoleModal.vue
@@ -90,12 +90,12 @@ export default {
         if (indexrole < 3) {
           this.$store.commit("players/setBluff", {
             index: indexrole,
-            role
+            role,
           });
         } else {
           this.$store.commit("players/setNotes", {
             index: indexrole - 3,
-            role
+            role,
           });
         }
       } else {

--- a/src/components/modals/RoleModal.vue
+++ b/src/components/modals/RoleModal.vue
@@ -85,11 +85,19 @@ export default {
   methods: {
     setRole(role) {
       if (this.playerIndex < 0) {
-        // assign to bluff slot (index < 0)
-        this.$store.commit("players/setBluff", {
-          index: this.playerIndex * -1 - 1,
-          role,
-        });
+        // assign to bluff slot or other slot (index < 0)
+        var indexrole = this.playerIndex * -1 - 1;
+        if (indexrole < 3) {
+          this.$store.commit("players/setBluff", {
+            index: indexrole,
+            role
+          });
+        } else {
+          this.$store.commit("players/setNotes", {
+            index: indexrole - 3,
+            role
+          });
+        }
       } else {
         if (this.session.isSpectator && role.team === "traveler") return;
         // assign to player

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,8 @@ const faIcons = [
   "BookOpen",
   "BookDead",
   "BroadcastTower",
+  "CaretDown",
+  "CaretUp",
   "Chair",
   "CheckSquare",
   "CloudMoon",

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -45,7 +45,7 @@ const getters = {
         otherNight.push(role);
       }
     });
-    notes.forEach(role => {
+    notes.forEach((role) => {
       if (role.firstNight && !firstNight.includes(role)) {
         firstNight.push(role);
       }

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -12,6 +12,7 @@ const state = () => ({
   players: [],
   fabled: [],
   bluffs: [],
+  notes: [],
 });
 
 const getters = {
@@ -25,10 +26,10 @@ const getters = {
     return Math.min(nonTravelers.length, 15);
   },
   // calculate a Map of player => night order
-  nightOrder({ players, fabled }) {
+  nightOrder({ players, fabled, notes }) {
     const firstNight = [0];
     const otherNight = [0];
-    fabled.forEach((role) => {
+    fabled.forEach(role => {
       if (role.firstNight && !firstNight.includes(role)) {
         firstNight.push(role);
       }
@@ -44,15 +45,30 @@ const getters = {
         otherNight.push(role);
       }
     });
+	notes.forEach(role => {
+      if (role.firstNight && !firstNight.includes(role)) {
+        firstNight.push(role);
+      }
+	  if (role.otherNight && !otherNight.includes(role)) {
+        otherNight.push(role);
+      }
+    });
+    
     firstNight.sort((a, b) => a.firstNight - b.firstNight);
-    otherNight.sort((a, b) => a.otherNight - b.otherNight);
+    otherNight.sort((a, b) => a.otherNight - b.otherNight);	
     const nightOrder = new Map();
+	
     players.forEach((player) => {
       const first = Math.max(firstNight.indexOf(player.role), 0);
       const other = Math.max(otherNight.indexOf(player.role), 0);
       nightOrder.set(player, { first, other });
     });
     fabled.forEach((role) => {
+      const first = Math.max(firstNight.indexOf(role), 0);
+      const other = Math.max(otherNight.indexOf(role), 0);
+      nightOrder.set(role, { first, other });
+    });
+    notes.forEach(role => {
       const first = Math.max(firstNight.indexOf(role), 0);
       const other = Math.max(otherNight.indexOf(role), 0);
       nightOrder.set(role, { first, other });
@@ -89,6 +105,7 @@ const actions = {
     }
     commit("set", players);
     commit("setBluff");
+    commit("setNotes");
   },
 };
 
@@ -96,6 +113,7 @@ const mutations = {
   clear(state) {
     state.players = [];
     state.bluffs = [];
+    state.notes = [];
     state.fabled = [];
   },
   set(state, players = []) {
@@ -140,6 +158,13 @@ const mutations = {
       state.bluffs.splice(index, 1, role);
     } else {
       state.bluffs = [];
+    }
+  },
+  setNotes(state, { index, role } = {}) {
+    if (index !== undefined) {
+      state.notes.splice(index, 1, role);
+    } else {
+      state.notes = [];
     }
   },
   setFabled(state, { index, fabled } = {}) {

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -29,7 +29,7 @@ const getters = {
   nightOrder({ players, fabled, notes }) {
     const firstNight = [0];
     const otherNight = [0];
-    fabled.forEach(role => {
+    fabled.forEach((role) => {
       if (role.firstNight && !firstNight.includes(role)) {
         firstNight.push(role);
       }
@@ -45,19 +45,19 @@ const getters = {
         otherNight.push(role);
       }
     });
-	notes.forEach(role => {
+    notes.forEach(role => {
       if (role.firstNight && !firstNight.includes(role)) {
         firstNight.push(role);
       }
-	  if (role.otherNight && !otherNight.includes(role)) {
+      if (role.otherNight && !otherNight.includes(role)) {
         otherNight.push(role);
       }
     });
-    
+
     firstNight.sort((a, b) => a.firstNight - b.firstNight);
-    otherNight.sort((a, b) => a.otherNight - b.otherNight);	
+    otherNight.sort((a, b) => a.otherNight - b.otherNight);
     const nightOrder = new Map();
-	
+
     players.forEach((player) => {
       const first = Math.max(firstNight.indexOf(player.role), 0);
       const other = Math.max(otherNight.indexOf(player.role), 0);
@@ -68,7 +68,7 @@ const getters = {
       const other = Math.max(otherNight.indexOf(role), 0);
       nightOrder.set(role, { first, other });
     });
-    notes.forEach(role => {
+    notes.forEach((role) => {
       const first = Math.max(firstNight.indexOf(role), 0);
       const other = Math.max(otherNight.indexOf(role), 0);
       nightOrder.set(role, { first, other });


### PR DESCRIPTION
Quatre cases avec ordre nocturne, placées au-dessus des bluffs, permettant de prendre des notes. Pour les joueurs, cela peut être utile pour diverses raisons (noter qu'un rôle est en jeu même sans savoir qui, voir quand est-ce qu'un rôle se réveille par rapport aux autres, etc.), surtout pour le Démon qui utilise déjà ses trois bluffs.

Pour le Narrateur, ces cases peuvent être utiles dans diverses situations :
- En cas d'**Alchimiste**, de **Philosophe**, d'**Apprenti** ou d'**Amnésique**, pour noter le rôle correspondant à son pouvoir sans fausser son rôle (ni le nombre de Voyageurs affichés dans le cas de l'Apprenti).
- En cas d'**Athée**, pour noter les rôles mauvais dont on veut simuler la présence, et s'y tenir.
- En cas d'**Aliéné**, pour avoir un pense-bête pour les infos de Démon de la 1ʳᵉ nuit.
- En cas de **Cafteur**, pour noter les bluffs à donner aux Serviteurs
- En cas de **Médecin de Peste**, pour noter le pouvoir gagné
- En cas de **Cerenovus**, pour noter le rôle que la victime est persuadée d'être
- En cas de **Bébé monstre**, pour avoir un pense-bête sur son ordre nocturne
- ...