### PR TITLE
Uniformying the French word for "Healthy"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -383,7 +383,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous avez besoin d'un jeton de vote pour pouvoir voter. Les joueurs morts peuvent vous offrir leurs jetons de vote. S'ils le font, vous apprenez leur alignement. Vous êtes toujours sobre et en bonne santé."
+    "ability": "Vous avez besoin d'un jeton de vote pour pouvoir voter. Les joueurs morts peuvent vous offrir leurs jetons de vote. S'ils le font, vous apprenez leur alignement. Vous êtes toujours sobre et sain."
   },
   {
     "id": "grandmother",
@@ -1221,7 +1221,7 @@
       "Pouvoir doublé"
     ],
     "setup": false,
-    "ability": "Chaque nuit, un joueur profite d'un bonus jusqu'à la nuit suivante : soit il devient sobre et en bonne santé et n'aura que de vraies informations, soit il peut utiliser sa capacité deux fois aujourd'hui. Il sait de quel bonus il bénéficie."
+    "ability": "Chaque nuit, un joueur profite d'un bonus jusqu'à la nuit suivante : soit il devient sobre et sain et n'aura que de vraies informations, soit il peut utiliser sa capacité deux fois aujourd'hui. Il sait de quel bonus il bénéficie."
   },
   {
     "id": "harlot",


### PR DESCRIPTION
Vu que ça a été traduit par "sain" pour le Pukka, et que ça me semble une bonne traduction, autant utiliser la même traduction partout. Ça a en plus le mérite d'être un mot court, comme "sobre".