### PR TITLE
Changing the french word for "Minion"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -111,7 +111,7 @@
     "hatred": [
       {
         "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, Les Serviteurs ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter. "
+        "reason": "Si le Planteur de pavot est en jeu, Les Sbires ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter. "
       },
       {
         "id": "Magician",
@@ -227,7 +227,7 @@
     "hatred": [
       {
         "id": "Lil' Monsta",
-        "reason": "La Marionette est voisine d'un Serviteur, pas du Démon. La Marionette n'est pas réveillée pour décider qui baby-sitte le Bébé Monstre, et n'apprend pas qu'elle est Marionette si elle devient baby-sitter. "
+        "reason": "La Marionette est voisine d'un Sbire, pas du Démon. La Marionette n'est pas réveillée pour décider qui baby-sitte le Bébé Monstre, et n'apprend pas qu'elle est Marionette si elle devient baby-sitter. "
       },
       {
         "id": "Poppy Grower",
@@ -344,23 +344,23 @@
       },
       {
         "id": "Investigator",
-        "reason": "Les Émeutes apparaîssent comme des Serviteur pour l'Enquéteur. "
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Enquéteur. "
       },
       {
         "id": "Clockmaker",
-        "reason": "Les Émeutes apparaîssent comme des Serviteur pour l'Horloger. "
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Horloger. "
       },
       {
         "id": "Town Crier",
-        "reason": "Les Émeutes apparaîssent comme des Serviteur pour le Crieur public. "
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Crieur public. "
       },
       {
         "id": "Damsel",
-        "reason": "Les Émeutes apparaîssent comme des Serviteur pour la Demoiselle. "
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour la Demoiselle. "
       },
       {
         "id": "Preacher",
-        "reason": "Les Émeutes apparaîssent comme des Serviteur pour le Prêcheur. "
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Prêcheur. "
       }
     ]
   },
@@ -494,11 +494,11 @@
       },
       {
         "id": "Lil' Monsta",
-        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Serviteur et devient baby-sitter pour cette nuit."
+        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et devient baby-sitter pour cette nuit."
       },
       {
         "id": "Riot",
-        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Serviteurs. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Serviteurs deviennent des Émeutes aussi."
+        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Sbires. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Sbires deviennent des Émeutes aussi."
       }
     ]
   },
@@ -511,15 +511,15 @@
       },
       {
         "id": "Choirboy",
-        "reason": "Le Kazali ne peut pas choisir de changer le Roi en Serviteur si l'Enfant de choeur est en jeu."
+        "reason": "Le Kazali ne peut pas choisir de changer le Roi en Sbire si l'Enfant de choeur est en jeu."
       },
       {
         "id": "Goon",
-        "reason": "Si le Kazali choisit de transformer l'Homme de main en Serviteur, il devient ivre, et les Serviteurs restants sont choisis par le Narrateur sans prendre en compte les décisions du Kazali."
+        "reason": "Si le Kazali choisit de transformer l'Homme de main en Sbire, il devient ivre, et les Sbires restants sont choisis par le Narrateur sans prendre en compte les décisions du Kazali."
       },
       {
         "id": "Huntsman",
-        "reason": "Si le Kazali transforme la Demoiselle en Serviteur, et si le Chasseur est en jeu, un joueur bon devient Demoiselle."
+        "reason": "Si le Kazali transforme la Demoiselle en Sbire, et si le Chasseur est en jeu, un joueur bon devient Demoiselle."
       },
       {
         "id": "Marionette",
@@ -544,19 +544,19 @@
       },
       {
         "id": "Fearmonger",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Serviteur en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Sbire en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
       },
       {
         "id": "Goblin",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gobelin au Narrateur, un Serviteur en vie gagne la capacité de Gobelin en plus de sa propre capacité, et l'apprend."
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gobelin au Narrateur, un Sbire en vie gagne la capacité de Gobelin en plus de sa propre capacité, et l'apprend."
       },
       {
         "id": "Scarlet Woman",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gourgandine au Narrateur, un Serviteur en vie gagne la capacité de Gourgandine en plus de sa propre capacité, et l'apprend."
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gourgandine au Narrateur, un Sbire en vie gagne la capacité de Gourgandine en plus de sa propre capacité, et l'apprend."
       },
       {
         "id": "Spy",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité d'Espion au Narrateur, un Serviteur en vie gagne la capacité d'Espion en plus de sa propre capacité, et l'apprend."
+        "reason": "Si le Médecin de Peste aurait du donner la capacité d'Espion au Narrateur, un Sbire en vie gagne la capacité d'Espion en plus de sa propre capacité, et l'apprend."
       },
       {
         "id": "Marionette",

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -229,7 +229,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous pouvez apparaître comme Mauvais avec un rôle de Sbire ou de Démon, même après votre mort."
+    "ability": "Vous pouvez apparaître comme Mauvais avec un rôle de Serviteur ou de Démon, même après votre mort."
   },
   {
     "id": "saint",
@@ -2042,7 +2042,7 @@
       "Condamné"
     ],
     "setup": true,
-    "ability": "Chaque nuit*, un joueur peut mourir. Les exécutions ratent si seuls des joueurs Mauvais ont voté. Vous apparaissez également comme un Sbire. [La majorité des joueurs sont Légion]"
+    "ability": "Chaque nuit*, un joueur peut mourir. Les exécutions ratent si seuls des joueurs Mauvais ont voté. Vous apparaissez également comme un Serviteur. [La majorité des joueurs sont Légion]"
   },
   {
     "id": "leviathan",

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -37,15 +37,15 @@
     "edition": "tb",
     "team": "townsfolk",
     "firstNight": 37,
-    "firstNightReminder": "Indiquez un rôle de Serviteur en jeu et deux joueurs. L'un de ces joueurs est ce personnage.",
+    "firstNightReminder": "Indiquez un rôle de Sbire en jeu et deux joueurs. L'un de ces joueurs est ce personnage.",
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [
-      "Serviteur",
+      "Sbire",
       "Faux"
     ],
     "setup": false,
-    "ability": "Vous commencez la partie en connaissant le rôle de Serviteur d'un joueur parmi deux désignés."
+    "ability": "Vous commencez la partie en connaissant le rôle de Sbire d'un joueur parmi deux désignés."
   },
   {
     "id": "chef",
@@ -229,7 +229,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous pouvez apparaître comme Mauvais avec un rôle de Serviteur ou de Démon, même après votre mort."
+    "ability": "Vous pouvez apparaître comme Mauvais avec un rôle de Sbire ou de Démon, même après votre mort."
   },
   {
     "id": "saint",
@@ -308,13 +308,13 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 26,
-    "otherNightReminder": "Le Diablotin désigne un joueur, ce joueur meurt. Si le Diablotin se choisit lui-même, l'un de ses Serviteurs encore en vie devient le Diablotin.",
+    "otherNightReminder": "Le Diablotin désigne un joueur, ce joueur meurt. Si le Diablotin se choisit lui-même, l'un des Sbires encore en vie devient le Diablotin.",
     "reminders": [
       "Mort",
       "Diablotin"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, désignez un joueur: il meurt. Si vous vous suicidez de cette façon, l'un de vos Serviteurs encore en vie devient le Diablotin."
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. Si vous vous suicidez de cette façon, un Sbire devient le Diablotin."
   },
   {
     "id": "bureaucrat",
@@ -536,7 +536,7 @@
       "Tous Ivres"
     ],
     "setup": false,
-    "ability": "Quand un Serviteur meurt par exécution, tous les autres joueurs (sauf les Voyageurs) sont Ivres jusqu'à la tombée de la nuit."
+    "ability": "Quand un Sbire meurt par exécution, tous les autres joueurs (sauf les Voyageurs) sont Ivres jusqu'à la tombée de la nuit."
   },
   {
     "id": "tealady",
@@ -632,7 +632,7 @@
     "edition": "bmr",
     "team": "outsider",
     "firstNight": 9,
-    "firstNightReminder": "S'il y a 7 joueurs ou plus, indiquez à l'Aliéné un nombre de rôles de Serviteurs correspondant au nombre de Serviteurs en jeu et des joueurs pour chacuns de ces personnages. Montrez 3 jetons de personnages bons de votre choix. Si le faux personnage de Démon assigné à l'Aliéné a des actions de nuit, prétendez que vous lui faites réaliser ces actions. Placez le(s) marqueur(s) d'attaque de l'Aliéné. Réveillez le vrai Démon. Dévoilez au Démon les véritables Serviteurs et 3 bons personnages qui ne sont pas en jeu. Dévoilez au Démon qui est l'Aliéné. Si l'Aliéné a attaqué des joueurs, dévoilez au véritable Démon les joueurs marqués puis retirez les marqueurs de l'Aliéné.",
+    "firstNightReminder": "S'il y a 7 joueurs ou plus, indiquez à l'Aliéné un nombre de rôles de Sbires correspondant au nombre de Sbires en jeu et des joueurs pour chacuns de ces personnages. Montrez 3 jetons de personnages bons de votre choix. Si le faux personnage de Démon assigné à l'Aliéné a des actions de nuit, prétendez que vous lui faites réaliser ces actions. Placez le(s) marqueur(s) d'attaque de l'Aliéné. Réveillez le vrai Démon. Dévoilez au Démon les véritables Sbires et 3 bons personnages qui ne sont pas en jeu. Dévoilez au Démon qui est l'Aliéné. Si l'Aliéné a attaqué des joueurs, dévoilez au véritable Démon les joueurs marqués puis retirez les marqueurs de l'Aliéné.",
     "otherNight": 22,
     "otherNightReminder": "Permettez à l'Aliéné de réaliser les actions du Démon qu'il croit être. Placez le(s) marqueur(s) d'attaque. Si l'Aliéné a indiqué des joueurs, réveillez le Démon. Dévoilez au Démon les marqueurs de l'Aliéné puis retirez-les.",
     "reminders": [],
@@ -777,7 +777,7 @@
       "Apprenti"
     ],
     "setup": false,
-    "ability": "Au cours de votre première nuit, vous acquérez une capacité de villageois si vous êtes bon, ou une capacité de Serviteur si vous êtes Mauvais."
+    "ability": "Au cours de votre première nuit, vous acquérez une capacité de villageois si vous êtes bon, ou une capacité de Sbire si vous êtes Mauvais."
   },
   {
     "id": "matron",
@@ -842,12 +842,12 @@
     "edition": "snv",
     "team": "townsfolk",
     "firstNight": 43,
-    "firstNightReminder": "Indiquez à quelle distance le Démon se trouve de son Serviteur le plus proche (en nombre de maisons).",
+    "firstNightReminder": "Indiquez à quelle distance le Démon se trouve de son Sbire le plus proche (en nombre de maisons).",
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Vous commencez la partie en sachant à combien de maisons le Démon se trouve de son Serviteur le plus proche."
+    "ability": "Vous commencez la partie en sachant à combien de sièges le Démon se trouve de son Sbire le plus proche."
   },
   {
     "id": "dreamer",
@@ -916,13 +916,13 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 63,
-    "otherNightReminder": "Indiquez si un Serviteur a lancé une accusation aujourd'hui",
+    "otherNightReminder": "Indiquez si un Sbire a lancé une accusation aujourd'hui",
     "reminders": [
       "A Accusé",
       "N'a pas accusé"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, vous apprenez si un Serviteur a lancé une accusation aujourd'hui."
+    "ability": "Chaque nuit*, vous apprenez si un Sbire a lancé une accusation aujourd'hui."
   },
   {
     "id": "oracle",
@@ -1167,14 +1167,14 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 34,
-    "otherNightReminder": "Le Vigormortis désigne un joueur. Ce joueur meurt. Si c'est un Serviteur, l'un de ses voisins Villageois est empoisonné.",
+    "otherNightReminder": "Le Vigormortis désigne un joueur. Ce joueur meurt. Si c'est un Sbire, l'un de ses voisins Villageois est empoisonné.",
     "reminders": [
       "Mort",
       "Pouvoir conservé",
       "Empoisonné"
     ],
     "setup": true,
-    "ability": "Chaque nuit*, désignez un joueur : il meurt. Les Serviteurs que vous tuez conservent leurs pouvoirs après leur mort et empoisonnent l'un de leurs voisins villageois. [-1 Étranger]"
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. Les Sbires que vous tuez conservent leurs pouvoirs après leur mort et empoisonnent l'un de leurs voisins villageois. [-1 Étranger]"
   },
   {
     "id": "nodashii",
@@ -1347,14 +1347,14 @@
     "edition": "",
     "team": "townsfolk",
     "firstNight": 15,
-    "firstNightReminder": "Le Prêcheur désigne un joueur. Si c'est un Serviteur, réveillez-le et indiquez lui qu'il a été démasqué par le Prêcheur. Le Serviteur perd ses capacités.",
+    "firstNightReminder": "Le Prêcheur désigne un joueur. Si c'est un Sbire, réveillez-le et indiquez lui qu'il a été démasqué par le Prêcheur. Le Sbire perd ses capacités.",
     "otherNight": 7,
-    "otherNightReminder": "Le Prêcheur désigne un joueur. Si c'est un Serviteur, réveillez-le et indiquez lui qu'il a été démasqué par le Prêcheur. Le Serviteur perd ses capacités.",
+    "otherNightReminder": "Le Prêcheur désigne un joueur. Si c'est un Sbire, réveillez-le et indiquez lui qu'il a été démasqué par le Prêcheur. Le Sbire perd ses capacités.",
     "reminders": [
       "Sermonné"
     ],
     "setup": false,
-    "ability": "Chaque nuit, désignez un joueur: si c'est un Serviteur, il perd ses capacités et apprend que vous l'avez démasqué."
+    "ability": "Chaque nuit, désignez un joueur : si c'est un Sbire, il l'apprend. Les Sbires désignés n'ont pas de capacité."
   },
   {
     "id": "king",
@@ -1381,7 +1381,7 @@
     "reminders": [
       "Villageois vu",
       "Étranger vu",
-      "Serviteur vu",
+      "Sbire vu",
       "Démon vu"
     ],
     "setup": true,
@@ -1451,15 +1451,15 @@
     "edition": "",
     "team": "townsfolk",
     "firstNight": 14,
-    "firstNightReminder": "L'ingénieur décide s'il veut utiliser son pouvoir. S'il le fait, il désigne un personnage de Démon et autant de personnages de Serviteurs qu'il y en a en jeu. Remplacez les rôles des joueurs correspondants par les rôles désignés, puis réveillez-les un à un pour leur indiquer leurs nouveaux rôles.",
+    "firstNightReminder": "L'ingénieur décide s'il veut utiliser son pouvoir. S'il le fait, il désigne un personnage de Démon et autant de personnages de Sbires qu'il y en a en jeu. Remplacez les rôles des joueurs correspondants par les rôles désignés, puis réveillez-les un à un pour leur indiquer leurs nouveaux rôles.",
     "otherNight": 6,
-    "otherNightReminder": "S'il ne l'a pas encore fait, l'Ingénieur décide s'il veut utiliser son pouvoir. S'il le fait, il désigne un personnage de Démon et autant de personnages de Serviteurs qu'il y en a en jeu. Remplacez les rôles des joueurs correspondants par les rôles désignés, puis réveillez-les un à un pour leur indiquer leurs nouveaux rôles.",
+    "otherNightReminder": "S'il ne l'a pas encore fait, l'Ingénieur décide s'il veut utiliser son pouvoir. S'il le fait, il désigne un personnage de Démon et autant de personnages de Sbires qu'il y en a en jeu. Remplacez les rôles des joueurs correspondants par les rôles désignés, puis réveillez-les un à un pour leur indiquer leurs nouveaux rôles.",
     "reminders": [
       "Changé",
       "Épuisé"
     ],
     "setup": false,
-    "ability": "Une fois par partie, la nuit, choisissez quel Démon ou quels Serviteurs sont en jeu."
+    "ability": "Une fois par partie, la nuit, choisissez quel Démon ou quels Sbires sont en jeu."
   },
   {
     "id": "fisherman",
@@ -1505,7 +1505,7 @@
       "Alchimiste"
     ],
     "setup": false,
-    "ability": "Vous avez la capacité d'un Serviteur qui n'est pas en jeu."
+    "ability": "Vous avez la capacité d'un Sbire qui n'est pas en jeu."
   },
   {
     "id": "farmer",
@@ -1526,12 +1526,12 @@
     "edition": "",
     "team": "townsfolk",
     "firstNight": 6,
-    "firstNightReminder": "Aux Serviteurs, montrez le Magicien comme un autre Démon. Au Démon, montrez le Magicien comme un autre Serviteur.",
+    "firstNightReminder": "Aux Sbires, montrez le Magicien comme un autre Démon. Au Démon, montrez le Magicien comme un autre Sbire.",
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Le Démon croit que vous êtes un Serviteur. Les Serviteurs croient que vous êtes un Démon."
+    "ability": "Le Démon croit que vous êtes un Sbire. Les Sbires croient que vous êtes un Démon."
   },
   {
     "id": "choirboy",
@@ -1552,15 +1552,15 @@
     "edition": "",
     "team": "townsfolk",
     "firstNight": 5,
-    "firstNightReminder": "Ne donnez pas les informations sur leurs alliés au Démon et aux Serviteurs.",
+    "firstNightReminder": "Ne donnez pas les informations sur leurs alliés au Démon et aux Sbires.",
     "otherNight": 4,
-    "otherNightReminder": "Si le Cultivateur de Pavot est mort, indiquez au Démon et à ses Serviteurs qui sont leurs alliés.",
+    "otherNightReminder": "Si le Cultivateur de Pavot est mort, indiquez au Démon et à ses Sbires qui sont leurs alliés.",
     "reminders": [
       "Revélations",
       "Masqués"
     ],
     "setup": false,
-    "ability": "Le Démon et ses Serviteurs n'apprennent pas qui sont leurs alliés en début de partie. Si vous mourez, ils l'apprennent cette nuit."
+    "ability": "Le Démon et ses Sbires n'apprennent pas qui sont leurs alliés en début de partie. Si vous mourez, ils l'apprennent cette nuit."
   },
   {
     "id": "atheist",
@@ -1668,12 +1668,12 @@
     "edition": "",
     "team": "outsider",
     "firstNight": 8,
-    "firstNightReminder": "Reveillez les Serviteurs séparement et indiquez leur 3 personnages qui ne sont pas en jeu. Ces personnages peuvent différer ou être les mêmes que ceux montrés à d'autres Serviteurs et/ou au Démon.",
+    "firstNightReminder": "Reveillez les Sbires séparement et indiquez leur 3 personnages qui ne sont pas en jeu. Ces personnages peuvent différer ou être les mêmes que ceux montrés à d'autres Sbires et/ou au Démon.",
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Les Serviteurs commencent la partie en connaissant 3 personnages qui ne sont pas en jeu."
+    "ability": "Les Sbires commencent la partie en connaissant 3 personnages qui ne sont pas en jeu."
   },
   {
     "id": "acrobat",
@@ -1732,7 +1732,7 @@
       "Épuisé"
     ],
     "setup": false,
-    "ability": "Les Serviteurs savent que vous êtes en jeu. Si un Serviteur devine publiquement qui vous êtes (un seul essai), votre équipe a perdu."
+    "ability": "Les Sbires savent que vous êtes en jeu. Si un Sbire devine publiquement qui vous êtes (un seul essai), votre équipe a perdu."
   },
   {
     "id": "golem",
@@ -1775,7 +1775,7 @@
       "Capacité du Narrateur"
     ],
     "setup": false,
-    "ability": "Si vous mourez, le Narrateur gagne la capacité d’un Serviteur qui n’est pas en jeu."
+    "ability": "Si vous mourez, le Narrateur gagne la capacité d’un Sbire qui n’est pas en jeu."
   },
   {
     "id": "hatter",
@@ -1785,12 +1785,12 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 44,
-    "otherNightReminder": "À la mort du Chapelier, effacez les rôles des Serviteurs et des Démons. Réveillez-les l'un après l'autre, en leur demandant à chacun le rôle qu'il souhaite devenir. Si l'un d'eux demande le même rôle qu'un joueur qui a déjà choisi, demandez-lui de choisir un autre rôle. Modifier les rôles de ces joueurs en conséquence.",
+    "otherNightReminder": "À la mort du Chapelier, effacez les rôles des Sbires et des Démons. Réveillez-les l'un après l'autre, en leur demandant à chacun le rôle qu'il souhaite devenir. Si l'un d'eux demande le même rôle qu'un joueur qui a déjà choisi, demandez-lui de choisir un autre rôle. Modifier les rôles de ces joueurs en conséquence.",
     "reminders": [
       "Heure du Thé"
     ],
     "setup": false,
-    "ability": "Si vous êtes mort aujourd'hui (de jour comme de nuit), les Serviteurs et Démons peuvent choisir de devenir d'autres Serviteurs et Démons."
+    "ability": "Si vous êtes mort aujourd'hui (de jour comme de nuit), les Sbires et Démons peuvent choisir de devenir d'autres Sbires et Démons."
   },
   {
     "id": "widow",
@@ -1982,16 +1982,16 @@
     "edition": "",
     "team": "demon",
     "firstNight": 16,
-    "firstNightReminder": "Réveillez tous les Serviteurs ensemble, faites-les voter pour désigner quel joueur baby-sitte le Bébé Monstre.",
+    "firstNightReminder": "Réveillez tous les Sbires ensemble, faites-les voter pour désigner quel joueur baby-sitte le Bébé Monstre.",
     "otherNight": 38,
-    "otherNightReminder": "Réveillez tous les Serviteurs ensemble, faites-les voter pour désigner quel joueur baby-sitte le Bébé Monstre. Choisissez un joueur, il meurt.",
+    "otherNightReminder": "Réveillez tous les Sbires ensemble, faites-les voter pour désigner quel joueur baby-sitte le Bébé Monstre. Choisissez un joueur, il meurt.",
     "reminders": [],
     "remindersGlobal": [
       "Démon",
       "Mort"
     ],
     "setup": true,
-    "ability": "Chaque nuit, les Serviteurs choisissent qui sera le baby-sitter de Bébé monstre. Le Baby-sitter est considéré comme le Démon jusqu'à la tombée de la nuit. Un joueur meurt chaque nuit*. [+1 Serviteur, -1 Démon]"
+    "ability": "Chaque nuit, les Sbires choisissent qui sera le baby-sitter de Bébé monstre. Le Baby-sitter est considéré comme le Démon jusqu'à la tombée de la nuit. Un joueur meurt chaque nuit*. [+1 Sbire, -1 Démon]"
   },
   {
     "id": "lleech",
@@ -2042,7 +2042,7 @@
       "Condamné"
     ],
     "setup": true,
-    "ability": "Chaque nuit*, un joueur peut mourir. Les exécutions ratent si seuls des joueurs Mauvais ont voté. Vous apparaissez également comme un Serviteur. [La majorité des joueurs sont Légion]"
+    "ability": "Chaque nuit*, un joueur peut mourir. Les exécutions ratent si seuls des joueurs Mauvais ont voté. Vous apparaissez également comme un Sbire. [La majorité des joueurs sont Légion]"
   },
   {
     "id": "leviathan",
@@ -2082,7 +2082,7 @@
       "Jour 3"
     ],
     "setup": true,
-    "ability": "Les joueurs accusés meurent immédiatement sans vote mais peuvent accuser à leur tour. Le troisième jour, les joueurs accusés doivent accuser. À la fin du troisième jour, les mauvais gagnent. [Tous les Serviteurs sont des Émeutes]"
+    "ability": "Les joueurs accusés meurent immédiatement sans vote mais peuvent accuser à leur tour. Le troisième jour, les joueurs accusés doivent accuser. À la fin du troisième jour, les mauvais gagnent. [Tous les Sbires sont des Émeutes]"
   },
   {
     "id": "yaggababble",
@@ -2105,14 +2105,14 @@
     "edition": "",
     "team": "demon",
     "firstNight": 3,
-    "firstNightReminder": "Réveillez le Kazali. Celui-ci choisit un joueur et un rôle de Serviteur : changez le rôle de ce joueur. Répétez autant de fois qu'il faut de Serviteurs. Réveillez les joueurs désignés pour les informer de leurs nouveaux rôles.",
+    "firstNightReminder": "Réveillez le Kazali. Celui-ci choisit un joueur et un rôle de Sbire : changez le rôle de ce joueur. Répétez autant de fois qu'il faut de Sbires. Réveillez les joueurs désignés pour les informer de leurs nouveaux rôles.",
     "otherNight": 39,
     "otherNightReminder": "Le Kazali désigne un joueur : ce joueur meurt.",
     "reminders": [
       "Mort"
     ],
     "setup": true,
-    "ability": "Chaque nuit*, désignez un joueur : il meurt. [Vous choisissez quels joueurs sont quels Serviteurs. -? à +? Étrangers]"
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. [Vous choisissez quels joueurs sont quels Sbires. -? à +? Étrangers]"
   },
   {
     "id": "ojo",

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -314,7 +314,7 @@
       "Diablotin"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, désignez un joueur : il meurt. Si vous vous suicidez de cette façon, un Sbire devient le Diablotin."
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. Si vous vous suicidez de cette façon, un Sbire encore en vie devient le Diablotin."
   },
   {
     "id": "bureaucrat",

--- a/src/store/locale/fr/ui.json
+++ b/src/store/locale/fr/ui.json
@@ -199,10 +199,10 @@
       "custom": "Scénario Perso",
       "firstNight": "Première Nuit",
       "otherNights": "Autres Nuits",
-      "minionInfo": "Informations Serviteurs",
-      "minionInfoDescription": "S'il y a plusieurs Serviteurs, ils apprennent qui sont les autres Serviteurs. Indiquez aux Serviteurs qui est le Démon.",
+      "minionInfo": "Informations Sbires",
+      "minionInfoDescription": "S'il y a plusieurs Sbires, ils apprennent qui sont les autres Sbires. Indiquez aux Sbires qui est le Démon.",
       "demonInfo": "Info & Bluffs Démon",
-      "demonInfoDescription": "Indiquez au Démon qui sont ses serviteurs. Indiquez les rôles de 3 personnages bons qui ne sont pas en jeu.",
+      "demonInfoDescription": "Indiquez au Démon qui sont ses Sbires. Indiquez les rôles de 3 personnages bons qui ne sont pas en jeu.",
       "dawn": "Matin",
       "dawnDescription1": "Réveillez les joueurs.",
       "dawnDescription2": "Réveillez les joueurs, puis annoncez qui est mort cette nuit",
@@ -216,7 +216,7 @@
       "teamNames": {
         "townsfolk": "villageois",
         "outsider": "étranger",
-        "minion": "serviteur",
+        "minion": "sbires",
         "demon": "démon"
       }
     },


### PR DESCRIPTION
Le sondage était serré, mais du coup, "Serviteur" devient "Sbire".

J'en ai profité pour 3 changements mineurs sur des rôles qui contiennent ce mot :

- L'Horloger pour enlever le terme "maison", pas du tout dans la description originale et qui est moins clair que "siège"
- Le Diablotin pour être plus proche de l'original. De plus, on s'est rendu compte que parler de "vos" Sbires peut prêter à confusion si le Diablotin est gentil.
- Le Prêcheur. Tel que c'était traduit, les Sbires n'ont aucun moyen de récupérer leurs pouvoirs. C'est faux, ils les récupèrent si le Prêcheur perd le sien (ivresse, empoisonnement ou mort).

EDIT : J'ai annulé ce changement pour le Reclus et la Légion, parce que je vais modifier leurs descriptions dans un autre request, et que du coup ça devrait t'aider à gérer les conflits.