### PR TITLE
French translation of "Toymaker"

### DIFF
--- a/src/store/locale/fr/fabled.json
+++ b/src/store/locale/fr/fabled.json
@@ -80,7 +80,7 @@
       "Nuit sans attaque"
     ],
     "setup": false,
-    "name": "Fabricant de Jouet",
+    "name": "Vendeur de jouets",
     "team": "fabled",
     "ability": "Le Démon peut choisir de ne pas attaquer et doit le faire obligatoirement au moins une fois une fois au cours de la partie. Les joueurs Mauvais ont accès aux informations de début de partie normales."
   },


### PR DESCRIPTION
Pour le coup, on s'éloigne de la traduction littérale. Mais actuellement, le nom est trop long pour être correctement affiché.