### PR TITLE
French translation of "Seamstress"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -952,13 +952,13 @@
   },
   {
     "id": "seamstress",
-    "name": "Couturier",
+    "name": "Couturière",
     "edition": "snv",
     "team": "townsfolk",
     "firstNight": 45,
-    "firstNightReminder": "Si le Couturier désigne 2 joueurs, indiquez si ces joueurs sont dans la même équipe.",
+    "firstNightReminder": "Si la Couturière désigne 2 joueurs, indiquez si ces joueurs sont dans la même équipe.",
     "otherNight": 65,
-    "otherNightReminder": "Si le Couturier n'a pas encore utilisé son pouvoir et qu'il désigne 2 joueurs, indiquez si ces joueurs sont du même alignement.",
+    "otherNightReminder": "Si la Couturière n'a pas encore utilisé son pouvoir et qu'il désigne 2 joueurs, indiquez si ces joueurs sont du même alignement.",
     "reminders": [
       "Épuisé"
     ],


### PR DESCRIPTION
Quelques éléments dans le wiki ou dans des discussions sur des forums me donnent l'impression que "Seamstress" a été pensé pour être un**e** couturièr**e**.