### PR TITLE
French translation of "Lleech"

### DIFF
--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -369,15 +369,15 @@
     "hatred": [
       {
         "id": "Mastermind",
-        "reason": "Si le Cerveau est en vie et que l'hôte de la Sangsue meurt par execution, la Sangsue survit mais perd son pouvoir. "
+        "reason": "Si le Cerveau est en vie et que l'hôte de la Ssangssue meurt par execution, la Ssangssue survit mais perd son pouvoir. "
       },
       {
         "id": "Slayer",
-        "reason": "Si le Tueur tire sur l'hôte de la Sangsue, l'hôte meurt. "
+        "reason": "Si le Tueur tire sur l'hôte de la Ssangssue, l'hôte meurt. "
       },
       {
         "id": "Heretic",
-        "reason": "Si la Sangsue a empoisonné l'Hérétique, et si elle meurt, alors l'Hérétique reste empoisonné. "
+        "reason": "Si la Ssangssue a empoisonné l'Hérétique, et si elle meurt, alors l'Hérétique reste empoisonné. "
       }
     ]
   },

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1995,13 +1995,13 @@
   },
   {
     "id": "lleech",
-    "name": "Sangsue",
+    "name": "Ssangssue",
     "edition": "",
     "team": "demon",
     "firstNight": 17,
-    "firstNightReminder": "La Sangue désigne un joueur. Ce joueur est empoisonné.",
+    "firstNightReminder": "La Ssangssue désigne un joueur. Ce joueur est empoisonné.",
     "otherNight": 37,
-    "otherNightReminder": "La Sangsue désigne un joueur. Ce joueur meurt.",
+    "otherNightReminder": "La Ssangssue désigne un joueur. Ce joueur meurt.",
     "reminders": [
       "Mort",
       "Empoisonné permanent"


### PR DESCRIPTION
En VO, ce Démon s'appelle "Lleech", et non pas "Leech" avec un seul L.
C'est bien une faute d'orthographe volontaire, afin de ne pas laisser penser que c'est juste une sangsue basique.