### PR TITLE
French token for the Sweetheart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1049,7 +1049,7 @@
     "otherNight": 46,
     "otherNightReminder": "Si le Bien-aimé est mort aujourd'hui, choisissez un joueur qui sera définitivement Ivre.",
     "reminders": [
-      "Ivre définitif"
+      "Ivre"
     ],
     "setup": false,
     "ability": "Quand vous mourez, 1 joueur devient définitivement Ivre."


### PR DESCRIPTION
Même remarque que pour la description : l'ivresse n'est pas définitive. De plus, la VO utilise bien un marqueur "Drunk", pas "Permanent Drunk"