### PR TITLE
French translation of "Fibbin"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/store/locale/fr/fabled.json
+++ b/src/store/locale/fr/fabled.json
@@ -92,7 +92,7 @@
       "Utilisé"
     ],
     "setup": false,
-    "name": "Mensonge",
+    "name": "Menteur",
     "team": "fabled",
     "ability": "Une fois par partie, un joueur Bon peut recevoir une information fausse."
   },


### PR DESCRIPTION
Pour celle-là, j'ai hésité. Mais tous les rôles de BOTC, y compris les Fabuleux, sont des personnes, pas des concepts.
Fibbin, en soit ne veut pas dire grand-chose (c'est comme si on appelait ça "le Mentant"), et a donc l'air d'être un néologisme, mais "Menteur" me semble mieux que "Mensonge", en attendant de trouver mieux.