### PR TITLE
Correcting nomination messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcomming Version
 
 - Various corrections in the French version
+- Minor corrections in the English version
 
 ### Version 3.18.0
 

--- a/src/store/locale/en/ui.json
+++ b/src/store/locale/en/ui.json
@@ -120,7 +120,7 @@
       },
       "accusation": {
         "button": "Accusation",
-        "text": "$accusator accuses $accusee"
+        "text": "$accusator nominates $accusee"
       },
       "defense": {
         "button": "Defense",

--- a/src/store/locale/fr/ui.json
+++ b/src/store/locale/fr/ui.json
@@ -124,7 +124,7 @@
       },
       "defense": {
         "button": "Défense",
-        "text": "$accusee se défend de $accusator"
+        "text": "$accusee se défend contre $accusator"
       },
       "debate": {
         "button": "Débat",


### PR DESCRIPTION
Quelques changements dans les messages d'accusation

- En anglais, pour utiliser le terme officiel de "nominates".
- En français pour prévoir le cas où l'accusateur commence par une voyelle (ou si c'est le Narrateur, ce qui sera possible avec un futur request)