### PR TITLE
Translating Reference roles' hover text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
 ## Upcomming Version
+
+- Various corrections in the French version
+
+### Version 3.18.0
+
 - Adding a missing jinx
 - Updating night order (and its print)
 - Correcting automatic adding/deletion of Fabled

--- a/src/components/modals/ReferenceModal.vue
+++ b/src/components/modals/ReferenceModal.vue
@@ -8,7 +8,7 @@
       @click="toggleModal('nightOrder')"
       icon="cloud-moon"
       class="toggle"
-      title="Show Night Order"
+      :title="locale.modal.reference.nightOrder"
     />
     <h3>
       {{ locale.modal.reference.title }}

--- a/src/store/locale/en/ui.json
+++ b/src/store/locale/en/ui.json
@@ -218,7 +218,8 @@
         "outsider": "outsider",
         "minion": "minion",
         "demon": "demon"
-      }
+      },
+      "nightOrder": "Show Night Order"
     },
     "reminder": {
       "title": "Choose a reminder token:",

--- a/src/store/locale/fr/ui.json
+++ b/src/store/locale/fr/ui.json
@@ -218,7 +218,8 @@
         "outsider": "étranger",
         "minion": "serviteur",
         "demon": "démon"
-      }
+      },
+      "nightOrder": "Afficher l'Ordre Nocturne"
     },
     "reminder": {
       "title": "Apposer une note:",


### PR DESCRIPTION
Dans la référence de rôle, il y a un bouton tout en haut à gauche.
Le texte que j'ai traduit ici apparaît quand on survole ce bouton.