### PR TITLE
Shorter French description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,7 @@
 
 ## Upcomming Version
 
-- MAINT: changed french name for Fibbin from Mensonge to Menteur
-- MAINT: french translation inconcistancy for snake charmer
-- MAINT: changed french name for Baloonist from Montgolfier to Aéronaute
-- MAINT: adjustment to nomination messages
-- BUGFIX: missing translation in Roles modal
-- BUGFIX: missing translation in Night order modal
-- BUGFIX: reminder modal title from translation
+- Various corrections in the French version
 
 ### Version 3.18.0
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -699,7 +699,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Si le Démon meurt par exécution (mettant fin à la partie), jouez une journée de plus. Si un joueur est exécuté durant cette journée, son équipe perd."
+    "ability": "Si le Démon meurt par exécution (mettant fin à la partie), jouez une journée de plus. Si un joueur est alors exécuté, son équipe perd."
   },
   {
     "id": "zombuul",
@@ -714,7 +714,7 @@
       "Mort"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, si personne n'est mort aujourd'hui, désignez un joueur : il meurt. La première fois que vous mourez, vous vivez mais apparaissez mort."
+    "ability": "Chaque nuit*, si personne n'est mort aujourd'hui, désignez un joueur : il meurt. La 1re fois que vous mourez, vous vivez mais apparaissez mort."
   },
   {
     "id": "pukka",
@@ -1011,7 +1011,7 @@
       "Faux"
     ],
     "setup": false,
-    "ability": "Lors de votre première journée, devinez publiquement les personnages de 5 joueurs maximum. La nuit suivante, vous apprenez combien vous en avez deviné correctement."
+    "ability": "Durant votre 1er jour, devinez publiquement jusqu'à 5 personnages. Cette nuit, vous apprenez combien vous en avez deviné correctement."
   },
   {
     "id": "sage",
@@ -1067,7 +1067,7 @@
       "Échanges"
     ],
     "setup": false,
-    "ability": "Si vous êtes mort aujourd'hui (de jour comme de nuit), le Démon peut désigner 2 joueurs qui ne sont pas un autre Démon et échanger leurs personnages."
+    "ability": "Si vous êtes mort aujourd'hui (de jour ou de nuit), le Démon peut désigner 2 joueurs (pas un autre Démon) et échanger leur personnage."
   },
   {
     "id": "klutz",
@@ -1096,7 +1096,7 @@
       "Jumeau"
     ],
     "setup": false,
-    "ability": "Vous et un joueur de l'équipe adverse connaissez vos personnages respectifs. Si le bon joueur meurt par exécution, les Mauvais gagnent. Le bien ne peut pas gagner tant que les deux jumeaux sont en vie."
+    "ability": "Vous & un adversaire savez vos personnages respectifs. Si le bon est exécuté, les mauvais gagnent. Le bien ne peut gagner si vous 2 vivez."
   },
   {
     "id": "witch",
@@ -1139,7 +1139,7 @@
     "otherNightReminder": "Le Chaudronnier désigne un joueur et un personnage. Si ce personnage n'est pas en jeu, réveillez ce joueur et dévoillez-lui son nouveau personnage. Si le personnage est déjà en jeu, rien ne se passe.",
     "reminders": [],
     "setup": false,
-    "ability": "Chaque nuit*, désignez un joueur et un personnage. Si ce personnage n'est pas encore en jeu, ce joueur devient ce personnage. Si un Démon est créé ainsi, les morts cette nuit sont arbitraires."
+    "ability": "Chaque nuit*, désignez un joueur et le personnage qu’il devient (si pas en jeu). Si un Démon est créé, les morts cette nuit sont arbitraires."
   },
   {
     "id": "fanggu",
@@ -1157,7 +1157,7 @@
       "Épuisé"
     ],
     "setup": true,
-    "ability": "Chaque nuit*, désignez un joueur: il meurt. Le premier Étranger tué ainsi devient un Mauvais Fang Gu et vous mourez à sa place. [+1 Étranger]"
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. Le 1er Étranger tué ainsi devient un mauvais Fang Gu et vous mourez à sa place. [+1 Étranger]"
   },
   {
     "id": "vigormortis",
@@ -1205,7 +1205,7 @@
       "Mort"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, désignez un joueur : il meurt. Les capacités des villageois donnent toujours de fausses informations. Chaque jour, si personne n'est exécuté, les Mauvais gagnent."
+    "ability": "Chaque nuit*, désignez un joueur : il meurt. Les capacités de Villageois donnent de fausses infos. Le jour, sans exécution, les mauvais gagnent."
   },
   {
     "id": "barista",
@@ -1310,7 +1310,7 @@
       "Connu"
     ],
     "setup": true,
-    "ability": "Vous commencez la partie en sachant qu'un joueur est dans l'équipe des Mauvais. Si le joueur que vous connaissez meurt, vous apprenez un autre joueur de l'équipe des Mauvais. [Un des Villageois fait partie de l'équipe des Mauvais]"
+    "ability": "La nuit 1, vous apprenez 1 joueur mauvais. Si celui que vous savez meurt, vous apprenez un autre mauvais la nuit. [1 Villageois mauvais]"
   },
   {
     "id": "pixie",
@@ -1398,7 +1398,7 @@
     "otherNightReminder": "Si le Gourou change d'équipe, réveillez-le pour l'en informer.",
     "reminders": [],
     "setup": false,
-    "ability": "Chaque nuit, vous rejoignez l'équipe de l'un de vos voisins vivants. Si tous les bons joueurs choisissent de rejoindre votre secte, votre équipe gagne."
+    "ability": Chaque nuit, vous rejoignez l'équipe d'un voisin vivant. Si tous les bons joueurs choisissent de rejoindre votre secte, votre équipe gagne."
   },
   {
     "id": "lycanthrope",
@@ -1489,7 +1489,7 @@
       "Épuisé"
     ],
     "setup": true,
-    "ability": "Une fois par partie, la nuit, désignez un joueur vivant : la Demoiselle, si elle est désignée, devient un personnage de Villageois qui n'était pas en jeu. [+ Demoiselle]"
+    "ability": "Une fois par partie, la nuit, désignez un joueur vivant : la Demoiselle, si désignée, devient un Villageois qui n'était pas en jeu. [+ Demoiselle]"
   },
   {
     "id": "alchemist",
@@ -1573,7 +1573,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": true,
-    "ability": "Le Narrateur peut briser les règles du jeu. Si les joueurs exécutent le Narrateur, les bons remportent la partie, même si vous êtes mort. [Aucun joueur n'est Mauvais]"
+    "ability": "Le Narrateur peut briser les règles du jeu. S'il est exécuté, les bons gagnent, même si vous êtes mort. [Aucun joueur mauvais]"
   },
   {
     "id": "cannibal",
@@ -1589,7 +1589,7 @@
       "Mort"
     ],
     "setup": false,
-    "ability": "Vous avez la capacité du dernier joueur mort par exécution. S'il était Mauvais, vous êtes empoisonné jusqu'à ce qu'un joueur Bon meure par exécution."
+    "ability": "Vous avez la capacité du dernier mort par exécution. S'il était mauvais, vous êtes empoisonné jusqu'à ce qu'un bon meure par exécution."
   },
   {
     "id": "steward",
@@ -1704,7 +1704,7 @@
       "Épuisé"
     ],
     "setup": false,
-    "ability": "Un joueur est Ivre de façon permanente, même après votre mort. Une fois par partie, en privé, vous pouvez tenter de deviner qui est le joueur Ivre. Si vous voyez juste, le Narrateur vous dévoile qui est le Démon, si vous vous trompez, il vous indique un autre joueur comme étant le Démon."
+    "ability": "Un joueur est ivre, même après votre mort. Si vous devinez qui (un seul essai), vous apprenez le Démon, mais l'info est fausse en cas d'erreur."
   },
   {
     "id": "heretic",
@@ -1808,7 +1808,7 @@
       "Sait"
     ],
     "setup": false,
-    "ability": "Lors de votre première nuit, regardez le grimoire et désignez un joueur : il est empoisonné. Un des Bons joueurs sait qu'il y a une Veuve dans la partie."
+    "ability": "Lors de votre première nuit, regardez le Grimoire et désignez un joueur : il est empoisonné. Un joueur bon sait qu'il y a une Veuve dans la partie."
   },
   {
     "id": "fearmonger",
@@ -1823,7 +1823,7 @@
       "Peur"
     ],
     "setup": false,
-    "ability": "Chaque nuit, désignez un joueur. S'il est accusé par vous et exécuté, son équipe perd. Tout le monde sait si vous désignez un nouveau joueur."
+    "ability": "Chaque nuit, désignez un joueur : si vous l'accusez et l'exécutez, son équipe perd. Tout le monde sait si vous désignez un nouveau joueur."
   },
   {
     "id": "psychopath",
@@ -1836,7 +1836,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Chaque jour, avant les accusations, vous pouvez désigner publiquement un joueur : il meurt. Si vous êtes exécuté, vous ne mourez que si vous perdez à pierre-feuille-ciseaux."
+    "ability": "Chaque jour, avant les accusations, vous pouvez choisir un joueur en public : il meurt. Si exécuté, vous ne mourez qu'en perdant à chifoumi."
   },
   {
     "id": "goblin",
@@ -1851,7 +1851,7 @@
       "Annoncé"
     ],
     "setup": false,
-    "ability": "Si vous dites publiquement que vous êtes le Gobelin quand vous êtes accusé et que vous êtes exécuté durant la même journée, votre équipe gagne."
+    "ability": "Si vous révélez publiquement être le Gobelin quand vous êtes accusé et que vous êtes exécuté durant la même journée, votre équipe gagne."
   },
   {
     "id": "mephit",
@@ -2026,7 +2026,7 @@
       "Mourir"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, désignez 3 joueurs (tout le monde sait qui a été désigné). Chacun de ces joueurs choisit secrètement s'il veut vivre ou mourir, mais, si les 3 vivent, ils meurent tous les 3."
+    "ability": "Chaque nuit*, désignez 3 joueurs (tout le monde sait qui) : en secret, chacun choisit de vivre ou de mourir, mais si les 3 vivent, les 3 meurent."
   },
   {
     "id": "legion",
@@ -2064,7 +2064,7 @@
       "Jour 5"
     ],
     "setup": false,
-    "ability": "Si plus d'un Bon joueur est exécuté, les Mauvais gagnent. Tous les joueurs savent que votre personnage est en jeu. Après 5 jours, les Mauvais gagnent."
+    "ability": "Si plus d'un bon est exécuté, les mauvais gagnent. Tous les joueurs savent que vous êtes en jeu. Après le jour 5, les mauvais gagnent."
   },
   {
     "id": "riot",
@@ -2082,7 +2082,7 @@
       "Jour 3"
     ],
     "setup": true,
-    "ability": "Les joueurs accusés meurent immédiatement sans vote mais peuvent accuser à leur tour. Le troisième jour, les joueurs accusés doivent accuser. À la fin du troisième jour, les mauvais gagnent. [Tous les Serviteurs sont des Émeutes]"
+    "ability": "Les accusés meurent et peuvent alors accuser (le jour 3, ils doivent). Après le jour 3 les mauvais gagnent. [Tous les Sbires sont des Émeutes]"
   },
   {
     "id": "yaggababble",


### PR DESCRIPTION
Diverses descriptions que j'ai raccourcies pour les rendre aussi courtes qu'en VO. J'en ai profité pour corriger certaines erreurs (comme le jumeau bon qui doit juste être exécuté, même si ça ne le tue pas).
Je n'ai pas touché aux descriptions déjà modifiées dans d'autres requests.