### PR TITLE
Updating the Jinxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Updating jinxes
 
 ### Version 3.20.0
 

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -184,7 +184,7 @@
     "hatred": [
       {
         "id": "Balloonist",
-        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider was added."
+        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider might have been added."
       },
       {
         "id": "Huntsman",

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -453,10 +453,6 @@
       {
         "id": "Vizier",
         "reason": "The Vizier can die by execution if they are babysitting Lil' Monsta."
-      },
-	  {
-        "id": "Organ Grinder",
-        "reason": "Votes for the Organ Grinder count if the Organ Grinder is babysitting Lil' Monsta."
       }
     ]
   },

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -62,31 +62,6 @@
     ]
   },
   {
-    "id": "Widow",
-    "hatred": [
-      {
-        "id": "Alchemist",
-        "reason": "The Alchemist can not have the Widow ability."
-      },
-      {
-        "id": "Magician",
-        "reason": "When the Widow sees the Grimoire, the Demon and Magician's character tokens are removed."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "If the Poppy Grower is in play, the Widow does not see the Grimoire until the Poppy Grower dies."
-      },
-      {
-        "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Damsel",
-        "reason": "If the Widow is (or has been) in play, the Damsel is poisoned."
-      }
-    ]
-  },
-  {
     "id": "Godfather",
     "hatred": [
       {
@@ -119,12 +94,130 @@
         "reason": "If the Plague Doctor dies, a living Minion gains the Spy ability in addition to their own ability, and learns this."
       },
       {
+        "id": "Damsel",
+        "reason": "If the Spy is (or has been) in play, the Damsel is poisoned."
+      },
+      {
         "id": "Heretic",
         "reason": "Only one jinxed character can be in play."
+      }
+    ]
+  },
+  {
+    "id": "Cerenovus",
+    "hatred": [
+      {
+        "id": "Goblin",
+        "reason": "The Cerenovus may choose to make a player mad that they are the Goblin."
+      }
+    ]
+  },
+  {
+    "id": "Fearmonger",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor dies, a living Minion gains the Fearmonger ability in addition to their own ability, and learns this."
+      }
+    ]
+  },
+  {
+    "id": "Pit-Hag",
+    "hatred": [
+      {
+        "id": "Village Idiot",
+        "reason": "If there is a spare token, the Pit-Hag can create an extra Village Idiot. If so, the drunk Village Idiot might change."
+      },
+      {
+        "id": "Cult Leader",
+        "reason": "If the Pit-Hag turns an evil player into the Cult Leader, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Goon",
+        "reason": "If the Pit-Hag turns an evil player into the Goon, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Ogre",
+        "reason": "If the Pit-Hag turns an evil player into the Ogre, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Politician",
+        "reason": "If the Pit-Hag turns an evil player into the Politician, they can't turn good due to their own ability."
       },
       {
         "id": "Damsel",
-        "reason": "If the Spy is (or has been) in play, the Damsel is poisoned."
+        "reason": "If a Pit-Hag creates a Damsel, the Storyteller chooses which player it is."
+      },
+      {
+        "id": "Heretic",
+        "reason": "A Pit-Hag cannot create a Heretic. "
+      }
+    ]
+  },
+  {
+    "id": "Widow",
+    "hatred": [
+      {
+        "id": "Alchemist",
+        "reason": "The Alchemist can not have the Widow ability."
+      },
+      {
+        "id": "Magician",
+        "reason": "When the Widow sees the Grimoire, the Demon and Magician's character tokens are removed."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Poppy Grower is in play, the Widow does not see the Grimoire until the Poppy Grower dies."
+      },
+      {
+        "id": "Damsel",
+        "reason": "If the Widow is (or has been) in play, the Damsel is poisoned."
+      },
+      {
+        "id": "Heretic",
+        "reason": "Only one jinxed character can be in play."
+      }
+    ]
+  },
+  {
+    "id": "Marionette",
+    "hatred": [
+      {
+        "id": "Balloonist",
+        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider was added."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "If the Marionette thinks that they are the Huntsman, the Damsel was added."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "When the Poppy Grower dies, the Demon learns the Marionette but the Marionette learns nothing."
+      },
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Demon has a neighbor who is alive and a Townsfolk or Outsider when the Plague Doctor dies, that player becomes an evil Marionette. If there is already an extra evil player, this does not happen."
+      },
+      {
+        "id": "Damsel",
+        "reason": "The Marionette does not learn that a Damsel is in play."
+      },
+      {
+        "id": "Snitch",
+        "reason": "The Marionette does not learn 3 not in-play characters. The Demon learns an extra 3 instead."
+      },
+      {
+        "id": "Lil' Monsta",
+        "reason": "The Marionette neighbors a Minion, not the Demon. The Marionette is not woken to choose who takes the Lil' Monsta token, and does not learn they are the Marionette if they have the Lil' Monsta token."
+      }
+    ]
+  },
+  {
+    "id": "Evil Twin",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "The Storyteller cannot gain the Evil Twin ability if the Plague Doctor dies."
       }
     ]
   },
@@ -168,92 +261,28 @@
         "reason": "The Marionette neighbours the Summoner. The Summoner knows who the Marionette is."
       },
       {
-        "id": "Kazali",
-        "reason": "The Summoner cannot create an in-play Demon. If the Summoner creates a not-in-play Demon, deaths tonight are arbitrary."
-      },
-      {
         "id": "Pukka",
         "reason": "The Summoner may choose a player to become the Pukka on the 2nd night."
       },
       {
-        "id": "Lord of Typhon",
-        "reason": "If the Summoner creates a Lord of Typhon, the Lord of Typhon must neighbor a Minion. The other neighbor becomes a not-in-play evil Minion."
+        "id": "Kazali",
+        "reason": "The Summoner cannot create an in-play Demon. If the Summoner creates a not-in-play Demon, deaths tonight are arbitrary."
+      },
+      {
+        "id": "Zombuul",
+        "reason": "If the Summoner turns a dead player into the Zombuul, the Storyteller treats that player as a Zombuul that has died once."
       },
 	  {
         "id": "Legion",
         "reason": "If the Summoner creates Legion, most players (including all evil players) become evil Legion."
       },
       {
-        "id": "Zombuul",
-        "reason": "If the Summoner turns a dead player into the Zombuul, the Storyteller treats that player as a Zombuul that has died once."
+        "id": "Lord of Typhon",
+        "reason": "If the Summoner creates a Lord of Typhon, the Lord of Typhon must neighbor a Minion. The other neighbor becomes a not-in-play evil Minion."
       },
       {
         "id": "Riot",
         "reason": "If the Summoner creates Riot, the chosen player and all evil players become Riot. The chosen player must be one of the Summoner's good living neighbours."
-      }
-    ]
-  },
-  {
-    "id": "Cerenovus",
-    "hatred": [
-      {
-        "id": "Goblin",
-        "reason": "The Cerenovus may choose to make a player mad that they are the Goblin."
-      }
-    ]
-  },
-  {
-    "id": "Fearmonger",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "If the Plague Doctor dies, a living Minion gains the Fearmonger ability in addition to their own ability, and learns this."
-      }
-    ]
-  },
-  {
-    "id": "Pit-Hag",
-    "hatred": [
-      {
-        "id": "Village Idiot",
-        "reason": "If there is a spare token, the Pit-Hag can create an extra Village Idiot. If so, the drunk Village Idiot might change."
-      },
-      {
-        "id": "Cult Leader",
-        "reason": "If the Pit-Hag turns an evil player into the Cult Leader, they can't turn good due to their own ability."
-      },
-      {
-        "id": "Ogre",
-        "reason": "If the Pit-Hag turns an evil player into the Ogre, they can't turn good due to their own ability."
-      },
-      {
-        "id": "Goon",
-        "reason": "If the Pit-Hag turns an evil player into the Goon, they can't turn good due to their own ability."
-      },
-      {
-        "id": "Heretic",
-        "reason": "A Pit-Hag cannot create a Heretic. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "If a Pit-Hag creates a Damsel, the Storyteller chooses which player it is."
-      },
-      {
-        "id": "Politician",
-        "reason": "If the Pit-Hag turns an evil player into the Politician, they can't turn good due to their own ability."
-      }
-    ]
-  },
-  {
-    "id": "Baron",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "If the Storyteller gains the Baron ability, up to two players become out-of-play Outsiders."
-      },
-	  {
-        "id": "Heretic",
-        "reason": "The Baron might only add one Outsider, not two."
       }
     ]
   },
@@ -267,37 +296,20 @@
     ]
   },
   {
+    "id": "Boomdandy",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor is executed and the Storyteller would gain the Boomdandy ability, the Boomdandy ability triggers immediately."
+      }
+    ]
+  },
+  {
     "id": "Scarlet Woman",
     "hatred": [
       {
         "id": "Plague Doctor",
         "reason": "If the Plague Doctor dies, a living Minion gains the Scarlet Woman ability in addition to their own ability, and learns this."
-      }
-    ]
-  },
-  {
-    "id": "Evil Twin",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "The Storyteller cannot gain the Evil Twin ability if the Plague Doctor dies."
-      }
-    ]
-  },
-  {
-    "id": "Organ Grinder",
-    "hatred": [
-      {
-        "id": "Preacher",
-        "reason": "If the Preacher removes the Organ Grinder ability, the Organ Grinder keeps their ability but the Preacher keeps their eyes open when voting."
-      },
-	  {
-        "id": "Minstrel",
-        "reason": "If the Minstrel makes everyone drunk, the Organ Grinder keeps their ability but the Minstrel keeps their eyes open when voting."
-      },
-      {
-        "id": "Butler",
-        "reason": "If the Organ Grinder is causing eyes closed voting, the Butler may raise their hand to vote but their vote is only counted if their master voted too."
       }
     ]
   },
@@ -329,12 +341,12 @@
         "reason": "If the Vizier and Magician are both in play, the Demon does not learn the Minions."
       },
       {
-        "id": "Zealot",
-        "reason": "The Zealot might register as evil to the Vizier."
-      },
-      {
         "id": "Politician",
         "reason": "The Politician might register as evil to the Vizier."
+      },
+      {
+        "id": "Zealot",
+        "reason": "The Zealot might register as evil to the Vizier."
       },
       {
         "id": "Fearmonger",
@@ -343,44 +355,69 @@
     ]
   },
   {
-    "id": "Boomdandy",
+    "id": "Organ Grinder",
     "hatred": [
       {
-        "id": "Plague Doctor",
-        "reason": "If the Plague Doctor is executed and the Storyteller would gain the Boomdandy ability, the Boomdandy ability triggers immediately."
+        "id": "Preacher",
+        "reason": "If the Preacher removes the Organ Grinder ability, the Organ Grinder keeps their ability but the Preacher keeps their eyes open when voting."
+      },
+	  {
+        "id": "Minstrel",
+        "reason": "If the Minstrel makes everyone drunk, the Organ Grinder keeps their ability but the Minstrel keeps their eyes open when voting."
+      },
+      {
+        "id": "Butler",
+        "reason": "If the Organ Grinder is causing eyes closed voting, the Butler may raise their hand to vote but their vote is only counted if their master voted too."
       }
     ]
   },
   {
-    "id": "Marionette",
+    "id": "Boffin",
     "hatred": [
       {
-        "id": "Balloonist",
-        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider might have been added."
+        "id": "Village Idiot",
+        "reason": "If there is a spare token, the Boffin can give the Demon the Village Idiot ability."
       },
       {
-        "id": "Huntsman",
-        "reason": "If the Marionette thinks that they are the Huntsman, the Damsel was added."
+        "id": "Cult Leader",
+        "reason": "If the Demon has the Cult Leader ability, they can't turn good due to this ability."
       },
       {
-        "id": "Poppy Grower",
-        "reason": "When the Poppy Grower dies, the Demon learns the Marionette but the Marionette learns nothing."
+        "id": "Alchemist",
+        "reason": "If the Alchemist has the Boffin ability, the Alchemist does not learn what ability the Demon has."
       },
       {
-        "id": "Snitch",
-        "reason": "The Marionette does not learn 3 not in-play characters. The Demon learns an extra 3 instead."
+        "id": "Goon",
+        "reason": "If the Demon has the Goon ability, they can't turn good due to this ability."
       },
+      {
+        "id": "Ogre",
+        "reason": "The Demon cannot have the Ogre ability."
+      },
+      {
+        "id": "Drunk",
+        "reason": "If the Demon would have the Drunk ability, the Boffin chooses a Townsfolk player to have this ability instead."
+      },
+      {
+        "id": "Politician",
+        "reason": "The Demon cannot have the Politician ability."
+      },
+	  {
+        "id": "Heretic",
+        "reason": "The Demon cannot have the Heretic ability."
+      }
+    ]
+  },
+  {
+    "id": "Baron",
+    "hatred": [
       {
         "id": "Plague Doctor",
-        "reason": "If the Demon has a neighbor who is alive and a Townsfolk or Outsider when the Plague Doctor dies, that player becomes an evil Marionette. If there is already an extra evil player, this does not happen."
+        "reason": "If the Storyteller gains the Baron ability, up to two players become out-of-play Outsiders."
       },
-      {
-        "id": "Damsel",
-        "reason": "The Marionette does not learn that a Damsel is in play."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "The Marionette neighbors a Minion, not the Demon. The Marionette is not woken to choose who takes the Lil' Monsta token, and does not learn they are the Marionette if they have the Lil' Monsta token."
+	  {
+        "id": "Heretic",
+        "reason": "The Baron might only add one Outsider, not two."
       }
     ]
   },
@@ -390,6 +427,35 @@
       {
         "id": "Exorcist",
         "reason": "If the Exorcist chooses the Yaggababble, the Yaggababble ability does not kill tonight."
+      }
+    ]
+  },
+  {
+    "id": "Lil' Monsta",
+    "hatred": [
+      {
+        "id": "Magician",
+        "reason": "Each night, the Magician chooses a Minion: if that Minion & Lil' Monsta are alive, that Minion babysits Lil’ Monsta."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Poppy Grower is in play, Minions don't wake together. They are woken one by one, until one of them chooses to take the Lil' Monsta token."
+      },
+      {
+        "id": "Hatter",
+        "reason": "If a Demon chooses Lil' Monsta, they also choose a Minion to become and babysit Lil' Monsta tonight."
+      },
+      {
+        "id": "Scarlet Woman",
+        "reason": "If there are five or more players alive and the player holding the Lil' Monsta token dies, the Scarlet Woman is given the Lil' Monsta token tonight."
+      },
+      {
+        "id": "Vizier",
+        "reason": "The Vizier can die by execution if they are babysitting Lil' Monsta."
+      },
+	  {
+        "id": "Organ Grinder",
+        "reason": "Votes for the Organ Grinder count if the Organ Grinder is babysitting Lil' Monsta."
       }
     ]
   },
@@ -421,33 +487,60 @@
         "reason": "If the Kazali chooses to create a Marionette, they must choose one of their neighbors."
       }
     ]
-  },  
+  },
   {
-    "id": "Lil' Monsta",
+    "id": "Al-Hadikhia",
     "hatred": [
       {
-        "id": "Magician",
-        "reason": "Each night, the Magician chooses a Minion: if that Minion & Lil' Monsta are alive, that Minion babysits Lil’ Monsta."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "If the Poppy Grower is in play, Minions don't wake together. They are woken one by one, until one of them chooses to take the Lil' Monsta token."
-      },
-      {
-        "id": "Hatter",
-        "reason": "If a Demon chooses Lil' Monsta, they also choose a Minion to become and babysit Lil' Monsta tonight."
+        "id": "Mastermind",
+        "reason": "If the Al-Hadikhia dies by execution, and the Mastermind is alive, the Al-Hadikhia chooses 3 good players tonight: if all 3 choose to live, evil wins. Otherwise, good wins."
       },
       {
         "id": "Scarlet Woman",
-        "reason": "If there are five or more players alive and the player holding the Lil' Monsta token dies, the Scarlet Woman is given the Lil' Monsta token tonight."
-      },
-	  {
-        "id": "Organ Grinder",
-        "reason": "Votes for the Organ Grinder count if the Organ Grinder is babysitting Lil' Monsta."
+        "reason": "If there are two living Al-Hadikhias, the Scarlet Woman Al-Hadikhia becomes the Scarlet Woman again."
+      }
+    ]
+  },
+  {
+    "id": "Vortox",
+    "hatred": [
+      {
+        "id": "Banshee",
+        "reason": "If the Vortox is in play and the Demon kills the Banshee, the players still learn that the Banshee has died."
+      }
+    ]
+  },
+  {
+    "id": "Fang Gu",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "If the Fang Gu chooses an Outsider and dies, the Scarlet Woman does not become the Fang Gu."
+      }
+    ]
+  },
+  {
+    "id": "Legion",
+    "hatred": [
+      {
+        "id": "Preacher",
+        "reason": "If the Preacher chooses Legion, Legion keeps their ability, but the Preacher might learn they are Legion."
       },
       {
-        "id": "Vizier",
-        "reason": "The Vizier can die by execution if they are babysitting Lil' Monsta."
+        "id": "Engineer",
+        "reason": "Legion and the Engineer cannot both be in play at the start of the game. If the Engineer creates Legion, most players (including all evil players) become evil Legion."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "If Legion died by execution today, Legion keeps their ability, but the Minstrel might learn they are Legion."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "If the Hatter dies and Legion is in play, nothing happens. If the Hatter dies and an evil player chooses Legion, all current evil players become Legion."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "The Zealot might register as evil to Legion’s ability."
       }
     ]
   },
@@ -469,62 +562,6 @@
     ]
   },
   {
-    "id": "Vortox",
-    "hatred": [
-      {
-        "id": "Banshee",
-        "reason": "If the Vortox is in play and the Demon kills the Banshee, the players still learn that the Banshee has died."
-      }
-    ]
-  },
-  {
-    "id": "Legion",
-    "hatred": [
-      {
-        "id": "Preacher",
-        "reason": "If the Preacher chooses Legion, Legion keeps their ability, but the Preacher might learn they are Legion."
-      },
-      {
-        "id": "Engineer",
-        "reason": "Legion and the Engineer cannot both be in play at the start of the game. If the Engineer creates Legion, most players (including all evil players) become evil Legion."
-      },
-      {
-        "id": "Minstrel",
-        "reason": "If Legion died by execution today, Legion keeps their ability, but the Minstrel might learn they are Legion."
-      },
-	  {
-        "id": "Zealot",
-        "reason": "The Zealot might register as evil to Legion’s ability."
-      },
-	  {
-        "id": "Hatter",
-        "reason": "If the Hatter dies and Legion is in play, nothing happens. If the Hatter dies and an evil player chooses Legion, all current evil players become Legion."
-      }
-    ]
-  },
-  {
-    "id": "Al-Hadikhia",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "If there are two living Al-Hadikhias, the Scarlet Woman Al-Hadikhia becomes the Scarlet Woman again."
-      },
-      {
-        "id": "Mastermind",
-        "reason": "If the Al-Hadikhia dies by execution, and the Mastermind is alive, the Al-Hadikhia chooses 3 good players tonight: if all 3 choose to live, evil wins. Otherwise, good wins."
-      }
-    ]
-  },
-  {
-    "id": "Fang Gu",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "If the Fang Gu chooses an Outsider and dies, the Scarlet Woman does not become the Fang Gu."
-      }
-    ]
-  },
-  {
     "id": "Leviathan",
     "hatred": [
       {
@@ -540,10 +577,6 @@
         "reason": "If Leviathan nominates and executes the Soldier, the Soldier does not die."
       },
       {
-        "id": "Sage",
-        "reason": "If Leviathan is in play & the Sage dies by execution, they wake that night to use their ability. They are drunk if their nominator was good."
-      },
-      {
         "id": "Farmer",
         "reason": "If Leviathan is in play and a Farmer dies by execution, a good player becomes a Farmer that night."
       },	  
@@ -552,12 +585,16 @@
         "reason": "If Leviathan is in play & the Ravenkeeper dies by execution, they wake that night to use their ability. They are drunk if their nominator was good."
       },
       {
-        "id": "Mayor",
-        "reason": "If Leviathan is in play and no execution occurs on day 5, good wins."
+        "id": "Sage",
+        "reason": "If Leviathan is in play & the Sage dies by execution, they wake that night to use their ability. They are drunk if their nominator was good."
       },
       {
         "id": "Banshee",
         "reason": "If Leviathan is in play, and the Banshee dies by execution, all players learn that the Banshee has died, and the Banshee gains their ability."
+      },
+      {
+        "id": "Mayor",
+        "reason": "If Leviathan is in play and no execution occurs on day 5, good wins."
       },
 	  {
         "id": "Hatter",
@@ -625,12 +662,12 @@
         "reason": "If a Riot player nominates the Soldier, the Soldier does not die."
       },
       {
-        "id": "Pacifist",
-        "reason": "Players that die by nomination register as executed to the Pacifist."
+        "id": "Cannibal",
+        "reason": "Players that die by nomination register as executed to the Cannibal."
       },
       {
-        "id": "Sage",
-        "reason": "If a Riot player nominates and kills a Sage, the Sage uses their ability tonight."
+        "id": "Minstrel",
+        "reason": "Only one jinxed character can be in play."
       },
       {
         "id": "Farmer",
@@ -641,32 +678,36 @@
         "reason": "If a Riot player nominates and kills the Ravenkeeper, the Ravenkeeper uses their ability tonight."
       },
       {
-        "id": "Minstrel",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Cannibal",
-        "reason": "Players that die by nomination register as executed to the Cannibal."
-      },
-      {
-        "id": "Mayor",
-        "reason": "If the third day begins with just three players alive, the players may choose (as a group) not to nominate at all. If so (and a Mayor is alive) the Mayor's team wins."
+        "id": "Sage",
+        "reason": "If a Riot player nominates and kills a Sage, the Sage uses their ability tonight."
       },
       {
         "id": "Banshee",
         "reason": "If Riot nominates and kills the Banshee, all players learn that the Banshee has died, and the Banshee may nominate two players immediately."
       },
       {
-        "id": "Snitch",
-        "reason": "If the Snitch is in play, each Riot player gets an extra three bluffs."
+        "id": "Mayor",
+        "reason": "If the third day begins with just three players alive, the players may choose (as a group) not to nominate at all. If so (and a Mayor is alive) the Mayor's team wins."
+      },
+      {
+        "id": "Pacifist",
+        "reason": "Players that die by nomination register as executed to the Pacifist."
       },
       {
         "id": "Butler",
         "reason": "The Butler cannot nominate their master."
       },
+	  {
+        "id": "Golem",
+        "reason": "If The Golem nominates Riot, the Riot player does not die."
+      },
       {
         "id": "Saint",
         "reason": "If a good player nominates and kills the Saint, the Saint's team loses."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "If the Hatter dies, Riot is in play and a Riot chooses a different Demon, a normal evil team is created from the Riot players. If the Hatter dies and the Demon chooses Riot, Minions become Riot too."
       },
       {
         "id": "Zealot",
@@ -676,13 +717,9 @@
         "id": "Damsel",
         "reason": "Riot registers as a Minion to the Damsel."
       },
-	  {
-        "id": "Golem",
-        "reason": "If The Golem nominates Riot, the Riot player does not die."
-      },
-	  {
-        "id": "Hatter",
-        "reason": "If the Hatter dies, Riot is in play and a Riot chooses a different Demon, a normal evil team is created from the Riot players. If the Hatter dies and the Demon chooses Riot, Minions become Riot too."
+      {
+        "id": "Snitch",
+        "reason": "If the Snitch is in play, each Riot player gets an extra three bluffs."
       },
       {
         "id": "Devil's Advocate",

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -356,7 +356,7 @@
     "hatred": [
       {
         "id": "Balloonist",
-        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider was added."
+        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider might have been added."
       },
       {
         "id": "Huntsman",

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -9,15 +9,6 @@
     ]
   },
   {
-    "id": "Lycanthrope",
-    "hatred": [
-      {
-        "id": "Gambler",
-        "reason": "If the Lycanthrope is alive and the Gambler kills themselves at night, no other players can die tonight."
-      }
-    ]
-  },
-  {
     "id": "Philosopher",
     "hatred": [
       {
@@ -33,11 +24,15 @@
         "id": "Juggler",
         "reason": "If the Juggler guesses on their first day and dies by execution, tonight the living Cannibal learns how many guesses the Juggler got correct."
       },
-	  {
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Cannibal eats the Poppy Grower, then dies or loses the Poppy Grower ability, the Demon and Minions learn each other that night."
+      },
+      {
         "id": "Butler",
         "reason": "If the Cannibal gains the Butler ability, the Cannibal learns this."
       },
-	  {
+      {
         "id": "Zealot",
         "reason": "If the Cannibal gains the Zealot ability, the Cannibal learns this."
       }

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -9,11 +9,46 @@
     ]
   },
   {
-    "id": "Butler",
+    "id": "Lycanthrope",
     "hatred": [
       {
-        "id": "Cannibal",
+        "id": "Gambler",
+        "reason": "If the Lycanthrope is alive and the Gambler kills themselves at night, no other players can die tonight."
+      }
+    ]
+  },
+  {
+    "id": "Philosopher",
+    "hatred": [
+      {
+        "id": "Bounty Hunter",
+        "reason": "If the Philosopher gains the Bounty Hunter ability, a Townsfolk might turn evil."
+      }
+    ]
+  },
+  {
+    "id": "Cannibal",
+    "hatred": [
+      {
+        "id": "Juggler",
+        "reason": "If the Juggler guesses on their first day and dies by execution, tonight the living Cannibal learns how many guesses the Juggler got correct."
+      },
+	  {
+        "id": "Butler",
         "reason": "If the Cannibal gains the Butler ability, the Cannibal learns this."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "If the Cannibal gains the Zealot ability, the Cannibal learns this."
+      }
+    ]
+  },
+  {
+    "id": "Ogre",
+    "hatred": [
+      {
+        "id": "Recluse",
+        "reason": "If the Recluse registers as evil to the Ogre, the Ogre learns that they are evil."
       }
     ]
   },
@@ -27,180 +62,27 @@
     ]
   },
   {
-    "id": "Pit-Hag",
-    "hatred": [
-      {
-        "id": "Heretic",
-        "reason": "A Pit-Hag cannot create a Heretic. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "If a Pit-Hag creates a Damsel, the Storyteller chooses which player it is."
-      },
-      {
-        "id": "Politician",
-        "reason": "A Pit-hag cannot create an evil Politician."
-      },
-      {
-        "id": "Village Idiot",
-        "reason": "If there is a spare token, the Pit-Hag can create an extra Village Idiot. If so, the drunk Village Idiot might change."
-      }
-    ]
-  },
-  {
-    "id": "Cerenovus",
-    "hatred": [
-      {
-        "id": "Goblin",
-        "reason": "The Cerenovus may choose to make a player mad that they are the Goblin."
-      }
-    ]
-  },
-  {
-    "id": "Leviathan",
-    "hatred": [
-      {
-        "id": "Soldier",
-        "reason": "If Leviathan nominates and executes the Soldier, the Soldier does not die."
-      },
-      {
-        "id": "Monk",
-        "reason": "If Leviathan nominates and executes the player the Monk chose, that player does not die."
-      },
-      {
-        "id": "Innkeeper",
-        "reason": "If Leviathan nominates and executes a player the Innkeeper chose, that player does not die."
-      },
-      {
-        "id": "Ravenkeeper",
-        "reason": "If Leviathan is in play and the Ravenkeeper dies by execution, they wake that night to use their ability."
-      },
-      {
-        "id": "Sage",
-        "reason": "If Leviathan is in play and the Sage dies by execution, they wake that night to use their ability."
-      },
-      {
-        "id": "Farmer",
-        "reason": "If Leviathan is in play and a Farmer dies by execution, a good player becomes a Farmer that night."
-      },
-      {
-        "id": "Mayor",
-        "reason": "If Leviathan is in play and no execution occurs on day 5, good wins."
-      },
-      {
-        "id": "Pit-Hag",
-        "reason": "After day 5, the Pit-Hag cannot choose Leviathan."
-      }
-    ]
-  },
-  {
-    "id": "Al-Hadikhia",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "If there are two living Al-Hadikhias, the Scarlet Woman Al-Hadikhia becomes the Scarlet Woman again."
-      },
-      {
-        "id": "Mastermind",
-        "reason": "Only 1 jinxed character can be in play. Evil players start knowing which player and character it is."
-      }
-    ]
-  },
-  {
-    "id": "Lil' Monsta",
-    "hatred": [
-      {
-        "id": "Poppy Grower",
-        "reason": "If the Poppy Grower is in play, Minions don't wake together. They are woken one by one, until one of them chooses to take the Lil' Monsta token."
-      },
-      {
-        "id": "Magician",
-        "reason": "Only one jinxed character can be in play. "
-      },
-      {
-        "id": "Scarlet Woman",
-        "reason": "If there are five or more players alive and the player holding the Lil' Monsta token dies, the Scarlet Woman is given the Lil' Monsta token tonight."
-      }
-    ]
-  },
-  {
-    "id": "Lycanthrope",
-    "hatred": [
-      {
-        "id": "Gambler",
-        "reason": "If the Lycanthrope is alive and the Gambler kills themselves at night, no other players can die tonight."
-      }
-    ]
-  },
-  {
-    "id": "Legion",
-    "hatred": [
-      {
-        "id": "Engineer",
-        "reason": "Legion and the Engineer cannot both be in play at the start of the game. If the Engineer creates Legion, most players (including all evil players) become evil Legion."
-      },
-      {
-        "id": "Preacher",
-        "reason": "Only one jinxed character can be in play."
-      }
-    ]
-  },
-  {
-    "id": "Fang Gu",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "If the Fang Gu chooses an Outsider and dies, the Scarlet Woman does not become the Fang Gu."
-      }
-    ]
-  },
-  {
-    "id": "Spy",
-    "hatred": [
-      {
-        "id": "Magician",
-        "reason": "When the Spy sees the Grimoire, the Demon and the Magician's character tokens are removed."
-      },
-      {
-        "id": "Alchemist",
-        "reason": "The Alchemist cannot have the Spy ability."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "If the Poppy Grower is in play, the Spy does not see the Grimoire until the Poppy Grower dies."
-      },
-      {
-        "id": "Damsel",
-        "reason": "Only one jinxed character can be in play. "
-      },
-      {
-        "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
-      }
-    ]
-  },
-  {
     "id": "Widow",
     "hatred": [
       {
+        "id": "Alchemist",
+        "reason": "The Alchemist can not have the Widow ability."
+      },
+      {
         "id": "Magician",
-        "reason": "When the Widow sees the Grimoire, the Demon and the Magician's character tokens are removed."
+        "reason": "When the Widow sees the Grimoire, the Demon and Magician's character tokens are removed."
       },
       {
         "id": "Poppy Grower",
         "reason": "If the Poppy Grower is in play, the Widow does not see the Grimoire until the Poppy Grower dies."
       },
       {
-        "id": "Alchemist",
-        "reason": "The Alchemist cannot have the Widow ability."
+        "id": "Heretic",
+        "reason": "Only one jinxed character can be in play."
       },
       {
         "id": "Damsel",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "If the Widow is (or has been) in play, the Damsel is poisoned."
       }
     ]
   },
@@ -214,11 +96,258 @@
     ]
   },
   {
+    "id": "Spy",
+    "hatred": [
+      {
+        "id": "Alchemist",
+        "reason": "The Alchemist cannot have the Spy ability."
+      },
+      {
+        "id": "Magician",
+        "reason": "When the Spy sees the Grimoire, the Demon and the Magician's character tokens are removed."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Poppy Grower is in play, the Spy does not see the Grimoire until the Poppy Grower dies."
+      },
+      {
+        "id": "Ogre",
+        "reason": "The Spy registers as evil to the Ogre."
+      },
+	  {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor dies, a living Minion gains the Spy ability in addition to their own ability, and learns this."
+      },
+      {
+        "id": "Heretic",
+        "reason": "Only one jinxed character can be in play."
+      },
+      {
+        "id": "Damsel",
+        "reason": "If the Spy is (or has been) in play, the Damsel is poisoned."
+      }
+    ]
+  },
+  {
+    "id": "Summoner",
+    "hatred": [
+      {
+        "id": "Clockmaker",
+        "reason": "If the Summoner is in play, the Clockmaker does not receive their information until a Demon is created."
+      },
+      {
+        "id": "Preacher",
+        "reason": "If the Preacher chose the Summoner on or before the 3rd night, the Summoner chooses which Demon, but the Storyteller chooses which player."
+      },
+      {
+        "id": "Engineer",
+        "reason": "If the Engineer removes a Summoner from play before that Summoner uses their ability, the Summoner uses their ability immediately."
+      },
+      {
+        "id": "Courtier",
+        "reason": "If the Summoner is drunk on the 3rd night, the Summoner chooses which Demon, but the Storyteller chooses which player."
+      },
+      {
+        "id": "Alchemist",
+        "reason": "If there is an Alchemist-Summoner in play, the game starts with a Demon in play, as normal. If the Alchemist-Summoner chooses a player, they make that player a Demon but do not change their alignment."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Poppy Grower is alive when the Summoner acts, the Summoner chooses which Demon, but the Storyteller chooses which player."
+      },
+      {
+        "id": "Hatter",
+        "reason": "The Summoner cannot create an in-play Demon. If the Summoner creates a not-in-play Demon, deaths tonight are arbitrary."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "The Summoner cannot create an in-play Demon. If the Summoner creates a not-in-play Demon, deaths tonight are arbitrary."
+      },
+      {
+        "id": "Marionette",
+        "reason": "The Marionette neighbours the Summoner. The Summoner knows who the Marionette is."
+      },
+      {
+        "id": "Kazali",
+        "reason": "The Summoner cannot create an in-play Demon. If the Summoner creates a not-in-play Demon, deaths tonight are arbitrary."
+      },
+      {
+        "id": "Pukka",
+        "reason": "The Summoner may choose a player to become the Pukka on the 2nd night."
+      },
+      {
+        "id": "Lord of Typhon",
+        "reason": "If the Summoner creates a Lord of Typhon, the Lord of Typhon must neighbor a Minion. The other neighbor becomes a not-in-play evil Minion."
+      },
+	  {
+        "id": "Legion",
+        "reason": "If the Summoner creates Legion, most players (including all evil players) become evil Legion."
+      },
+      {
+        "id": "Zombuul",
+        "reason": "If the Summoner turns a dead player into the Zombuul, the Storyteller treats that player as a Zombuul that has died once."
+      },
+      {
+        "id": "Riot",
+        "reason": "If the Summoner creates Riot, the chosen player and all evil players become Riot. The chosen player must be one of the Summoner's good living neighbours."
+      }
+    ]
+  },
+  {
+    "id": "Cerenovus",
+    "hatred": [
+      {
+        "id": "Goblin",
+        "reason": "The Cerenovus may choose to make a player mad that they are the Goblin."
+      }
+    ]
+  },
+  {
+    "id": "Fearmonger",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor dies, a living Minion gains the Fearmonger ability in addition to their own ability, and learns this."
+      }
+    ]
+  },
+  {
+    "id": "Pit-Hag",
+    "hatred": [
+      {
+        "id": "Village Idiot",
+        "reason": "If there is a spare token, the Pit-Hag can create an extra Village Idiot. If so, the drunk Village Idiot might change."
+      },
+      {
+        "id": "Cult Leader",
+        "reason": "If the Pit-Hag turns an evil player into the Cult Leader, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Ogre",
+        "reason": "If the Pit-Hag turns an evil player into the Ogre, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Goon",
+        "reason": "If the Pit-Hag turns an evil player into the Goon, they can't turn good due to their own ability."
+      },
+      {
+        "id": "Heretic",
+        "reason": "A Pit-Hag cannot create a Heretic. "
+      },
+      {
+        "id": "Damsel",
+        "reason": "If a Pit-Hag creates a Damsel, the Storyteller chooses which player it is."
+      },
+      {
+        "id": "Politician",
+        "reason": "If the Pit-Hag turns an evil player into the Politician, they can't turn good due to their own ability."
+      }
+    ]
+  },
+  {
     "id": "Baron",
     "hatred": [
       {
+        "id": "Plague Doctor",
+        "reason": "If the Storyteller gains the Baron ability, up to two players become out-of-play Outsiders."
+      },
+	  {
         "id": "Heretic",
         "reason": "The Baron might only add one Outsider, not two."
+      }
+    ]
+  },
+  {
+    "id": "Goblin",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor dies, a living Minion gains the Goblin ability in addition to their own ability, and learns this."
+      }
+    ]
+  },
+  {
+    "id": "Scarlet Woman",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor dies, a living Minion gains the Scarlet Woman ability in addition to their own ability, and learns this."
+      }
+    ]
+  },
+  {
+    "id": "Evil Twin",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "The Storyteller cannot gain the Evil Twin ability if the Plague Doctor dies."
+      }
+    ]
+  },
+  {
+    "id": "Organ Grinder",
+    "hatred": [
+      {
+        "id": "Preacher",
+        "reason": "If the Preacher removes the Organ Grinder ability, the Organ Grinder keeps their ability but the Preacher keeps their eyes open when voting."
+      },
+	  {
+        "id": "Minstrel",
+        "reason": "If the Minstrel makes everyone drunk, the Organ Grinder keeps their ability but the Minstrel keeps their eyes open when voting."
+      },
+      {
+        "id": "Butler",
+        "reason": "If the Organ Grinder is causing eyes closed voting, the Butler may raise their hand to vote but their vote is only counted if their master voted too."
+      }
+    ]
+  },
+  {
+    "id": "Vizier",
+    "hatred": [
+      {
+        "id": "Investigator",
+        "reason": "If the Investigator learns that the Vizier is in play, the existence of the Vizier is not announced by the Storyteller."
+      },
+      {
+        "id": "Preacher",
+        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
+      },
+      {
+        "id": "Alsaahir",
+        "reason": "If the Vizier is in play, the Alsaahir must also guess which Demon(s) are in play."
+      },
+      {
+        "id": "Courtier",
+        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
+      },
+      {
+        "id": "Alchemist",
+        "reason": "If the Alchemist has the Vizier ability, they may only choose to execute immediately if three or more players voted, regardless of those players' alignment."
+      },
+	  {
+        "id": "Magician",
+        "reason": "If the Vizier and Magician are both in play, the Demon does not learn the Minions."
+      },
+      {
+        "id": "Zealot",
+        "reason": "The Zealot might register as evil to the Vizier."
+      },
+      {
+        "id": "Politician",
+        "reason": "The Politician might register as evil to the Vizier."
+      },
+      {
+        "id": "Fearmonger",
+        "reason": "The Vizier wakes with the Fearmonger, learns who they choose and cannot choose to execute that player."
+      }
+    ]
+  },
+  {
+    "id": "Boomdandy",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "If the Plague Doctor is executed and the Storyteller would gain the Boomdandy ability, the Boomdandy ability triggers immediately."
       }
     ]
   },
@@ -226,8 +355,12 @@
     "id": "Marionette",
     "hatred": [
       {
-        "id": "Lil' Monsta",
-        "reason": "The Marionette neighbors a Minion, not the Demon. The Marionette is not woken to choose who takes the Lil' Monsta token, and does not learn they are the Marionette if they have the Lil' Monsta token."
+        "id": "Balloonist",
+        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider was added."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "If the Marionette thinks that they are the Huntsman, the Damsel was added."
       },
       {
         "id": "Poppy Grower",
@@ -238,171 +371,16 @@
         "reason": "The Marionette does not learn 3 not in-play characters. The Demon learns an extra 3 instead."
       },
       {
-        "id": "Balloonist",
-        "reason": "If the Marionette thinks that they are the Balloonist, +1 Outsider was added."
+        "id": "Plague Doctor",
+        "reason": "If the Demon has a neighbor who is alive and a Townsfolk or Outsider when the Plague Doctor dies, that player becomes an evil Marionette. If there is already an extra evil player, this does not happen."
       },
       {
         "id": "Damsel",
         "reason": "The Marionette does not learn that a Damsel is in play."
       },
       {
-        "id": "Huntsman",
-        "reason": "If the Marionette thinks that they are the Huntsman, the Damsel was added."
-      }
-    ]
-  },
-  {
-    "id": "Riot",
-    "hatred": [
-      {
-        "id": "Engineer",
-        "reason": "Riot and the Engineer cannot both be in play at the start of the game. If the Engineer creates Riot, the evil players become Riot."
-      },
-      {
-        "id": "Golem",
-        "reason": "If The Golem nominates Riot, the Riot player does not die."
-      },
-      {
-        "id": "Snitch",
-        "reason": "If the Snitch is in play, each Riot player gets an extra three bluffs."
-      },
-      {
-        "id": "Saint",
-        "reason": "If a good player nominates and kills the Saint, the Saint's team loses."
-      },
-      {
-        "id": "Butler",
-        "reason": "The Butler cannot nominate their master."
-      },
-      {
-        "id": "Pit-Hag",
-        "reason": "If the Pit-Hag creates Riot, all evil players become Riot. If the Pit-Hag creates Riot after day 3, the game continues for one more day."
-      },
-      {
-        "id": "Mayor",
-        "reason": "If the third day begins with just three players alive, the players may choose (as a group) not to nominate at all. If so (and a Mayor is alive) the Mayor's team wins."
-      },
-      {
-        "id": "Monk",
-        "reason": "If a Riot player nominates a Monk-protected player, the protected-player does not die."
-      },
-      {
-        "id": "Farmer",
-        "reason": "If a Riot player nominates and kills a Farmer, the Farmer uses their ability tonight."
-      },
-      {
-        "id": "Innkeeper",
-        "reason": "If a Riot player nominates an Innkeeper-protected player, the protected-player does not die."
-      },
-      {
-        "id": "Sage",
-        "reason": "If a Riot player nominates and kills a Sage, the Sage uses their ability tonight."
-      },
-      {
-        "id": "Ravenkeeper",
-        "reason": "If a Riot player nominates and kills the Ravenkeeper, the Ravenkeeper uses their ability tonight."
-      },
-      {
-        "id": "Soldier",
-        "reason": "If a Riot player nominates the Soldier, the Soldier does not die."
-      },
-      {
-        "id": "Grandmother",
-        "reason": "If a Riot player nominates and kills the grandchild, the Grandmother dies too."
-      },
-      {
-        "id": "King",
-        "reason": "If a Riot player nominates and kills the King and the Choirboy is alive, the Choirboy uses their ability tonight."
-      },
-      {
-        "id": "Exorcist",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Minstrel",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Flowergirl",
-        "reason": "Only one jinxed character can be in play."
-      },
-      {
-        "id": "Undertaker",
-        "reason": "Players that die by nomination register as executed to the Undertaker."
-      },
-      {
-        "id": "Cannibal",
-        "reason": "Players that die by nomination register as executed to the Cannibal."
-      },
-      {
-        "id": "Pacifist",
-        "reason": "Players that die by nomination register as executed to the Pacifist."
-      },
-      {
-        "id": "Devil's Advocate",
-        "reason": "Players that die by nomination register as executed to the Devil's Advocate."
-      },
-      {
-        "id": "Investigator",
-        "reason": "Riot registers as a Minion to the Investigator."
-      },
-      {
-        "id": "Clockmaker",
-        "reason": "Riot registers as a Minion to the Clockmaker."
-      },
-      {
-        "id": "Town Crier",
-        "reason": "Riot registers as a Minion to the Town Crier."
-      },
-      {
-        "id": "Damsel",
-        "reason": "Riot registers as a Minion to the Damsel."
-      },
-      {
-        "id": "Preacher",
-        "reason": "Riot registers as a Minion to the Preacher."
-      }
-    ]
-  },
-  {
-    "id": "Lleech",
-    "hatred": [
-      {
-        "id": "Mastermind",
-        "reason": "If the Mastermind is alive and the Lleech's host dies by execution, the Lleech lives but loses their ability. "
-      },
-      {
-        "id": "Slayer",
-        "reason": "If the Slayer shoots the Lleech's host, the host dies. "
-      },
-      {
-        "id": "Heretic",
-        "reason": "If the Lleech has poisoned the Heretic then the Lleech dies, the Heretic remains poisoned."
-      }
-    ]
-  },
-  {
-    "id": "Organ Grinder",
-    "hatred": [
-      {
-        "id": "Butler",
-        "reason": "If the Organ Grinder is causing eyes closed voting, the Butler may raise their hand to vote but their vote is only counted if their master voted too."
-      },
-      {
-        "id": "Flowergirl",
-        "reason": "If players' eyes were closed during the nominations, the Flowergirl learns how many times the Demon voted."
-      },
-      {
         "id": "Lil' Monsta",
-        "reason": "Votes for the Organ Grinder count if the Organ Grinder is babysitting Lil' Monsta."
-      },
-      {
-        "id": "Minstrel",
-        "reason": "Only 1 jinxed character can be in play. Evil players start knowing which player and character it is."
-      },
-      {
-        "id": "Preacher",
-        "reason": "Only 1 jinxed character can be in play. Evil players start knowing which player and character it is."
+        "reason": "The Marionette neighbors a Minion, not the Demon. The Marionette is not woken to choose who takes the Lil' Monsta token, and does not learn they are the Marionette if they have the Lil' Monsta token."
       }
     ]
   },
@@ -416,135 +394,19 @@
     ]
   },
   {
-    "id": "Plague Doctor",
-    "hatred": [
-      {
-        "id": "Baron",
-        "reason": "If the Storyteller gains the Baron ability, up to two players become out-of-play Outsiders."
-      },
-      {
-        "id": "Boomdandy",
-        "reason": "If the Plague Doctor is executed and the Storyteller would gain the Boomdandy ability, the Boomdandy ability triggers immediately."
-      },
-      {
-        "id": "Evil Twin",
-        "reason": "The Storyteller cannot gain the Evil Twin ability if the Plague Doctor dies."
-      },
-      {
-        "id": "Fearmonger",
-        "reason": "If the Plague Doctor dies, a living Minion gains the Fearmonger ability in addition to their own ability, and learns this."
-      },
-      {
-        "id": "Goblin",
-        "reason": "If the Plague Doctor dies, a living Minion gains the Goblin ability in addition to their own ability, and learns this."
-      },
-      {
-        "id": "Scarlet Woman",
-        "reason": "If the Plague Doctor dies, a living Minion gains the Scarlet Woman ability in addition to their own ability, and learns this."
-      },
-      {
-        "id": "Spy",
-        "reason": "If the Plague Doctor dies, a living Minion gains the Spy ability in addition to their own ability, and learns this."
-      },
-      {
-        "id": "Marionette",
-        "reason": "If the Demon has a neighbor who is alive and a Townsfolk or Outsider when the Plague Doctor dies, that player becomes an evil Marionette. If there is already an extra evil player, this does not happen."
-      }
-    ]
-  },
-  {
-    "id": "Summoner",
-    "hatred": [
-      {
-        "id": "Alchemist",
-        "reason": "If there is an Alchemist-Summoner in play, the game starts with a Demon in play, as normal. If the Alchemist-Summoner chooses a player, they make that player a Demon but do not change their alignment."
-      },
-      {
-        "id": "Clockmaker",
-        "reason": "If the Summoner is in play, the Clockmaker does not receive their information until a Demon is created."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "If the Poppy Grower is alive when the Summoner acts, the Summoner chooses which Demon, but the Storyteller chooses which player."
-      },
-      {
-        "id": "Marionette",
-        "reason": "The Marionette neighbours the Summoner. The Summoner knows who the Marionette is."
-      },
-      {
-        "id": "Kazali",
-        "reason": "The Kazali can not choose to create a Summoner."
-      },
-      {
-        "id": "Legion",
-        "reason": "If the Summoner creates Legion, most players (including all evil players) become evil Legion."
-      },
-      {
-        "id": "Riot",
-        "reason": "If the Summoner creates Riot, the chosen player and all evil players become Riot. The chosen player must be one of the Summoner's good living neighbours."
-      }
-    ]
-  },
-  {
-    "id": "Vizier",
-    "hatred": [
-      {
-        "id": "Magician",
-        "reason": "Only 1 jinxed character can be in play. Evil players start knowing which player and character it is."
-      },
-      {
-        "id": "Alchemist",
-        "reason": "If the Alchemist has the Vizier ability, they may only choose to execute immediately if three or more players voted, regardless of those players' alignment."
-      },
-      {
-        "id": "Courtier",
-        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
-      },
-      {
-        "id": "Preacher",
-        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
-      },
-      {
-        "id": "Investigator",
-        "reason": "If the Investigator learns that the Vizier is in play, the existence of the Vizier is not announced by the Storyteller."
-      },
-      {
-        "id": "Fearmonger",
-        "reason": "The Vizier wakes with the Fearmonger, learns who they choose and cannot choose to execute that player."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "The Vizier can die by execution if they are babysitting Lil' Monsta."
-      }
-    ]
-  },
-  {
-    "id": "Hatter",
-    "hatred": [
-      {
-        "id": "Legion",
-        "reason": "If the Hatter dies and Legion is in play, nothing happens. If the Hatter dies and an evil player chooses Legion, all current evil players become Legion."
-      },
-      {
-        "id": "Leviathan",
-        "reason": "If the Hatter dies on or after day 5, the Demon cannot choose Leviathan."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "If a Demon chooses Lil' Monsta, they also choose a Minion to become and babysit Lil' Monsta tonight."
-      },
-      {
-        "id": "Riot",
-        "reason": "If the Hatter dies, Riot is in play and a Riot chooses a different Demon, a normal evil team is created from the Riot players. If the Hatter dies and the Demon chooses Riot, Minions become Riot too."
-      }
-    ]
-  },
-  {
     "id": "Kazali",
     "hatred": [
       {
         "id": "Bounty Hunter",
         "reason": "An evil Townsfolk is only created if the Bounty Hunter is still in play after the Kazali acts."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "If the Kazali chooses the Damsel to become a Minion, and a Huntsman is in play, a good player becomes the Damsel."
+      },
+      {
+        "id": "Soldier",
+        "reason": "If the Kazali turns the Soldier into a Minion, the Soldier chooses which not-in-play Minion to become."
       },
       {
         "id": "Choirboy",
@@ -555,12 +417,280 @@
         "reason": "If the Kazali chooses the Goon to become a Minion, remaining Minions choices are decided by the Storyteller."
       },
       {
-        "id": "Huntsman",
-        "reason": "If the Kazali chooses the Damsel to become a Minion, and a Huntsman is in play, a good player becomes the Damsel."
-      },
-      {
         "id": "Marionette",
         "reason": "If the Kazali chooses to create a Marionette, they must choose one of their neighbors."
+      }
+    ]
+  },  
+  {
+    "id": "Lil' Monsta",
+    "hatred": [
+      {
+        "id": "Magician",
+        "reason": "Each night, the Magician chooses a Minion: if that Minion & Lil' Monsta are alive, that Minion babysits Lil’ Monsta."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "If the Poppy Grower is in play, Minions don't wake together. They are woken one by one, until one of them chooses to take the Lil' Monsta token."
+      },
+      {
+        "id": "Hatter",
+        "reason": "If a Demon chooses Lil' Monsta, they also choose a Minion to become and babysit Lil' Monsta tonight."
+      },
+      {
+        "id": "Scarlet Woman",
+        "reason": "If there are five or more players alive and the player holding the Lil' Monsta token dies, the Scarlet Woman is given the Lil' Monsta token tonight."
+      },
+	  {
+        "id": "Organ Grinder",
+        "reason": "Votes for the Organ Grinder count if the Organ Grinder is babysitting Lil' Monsta."
+      },
+      {
+        "id": "Vizier",
+        "reason": "The Vizier can die by execution if they are babysitting Lil' Monsta."
+      }
+    ]
+  },
+  {
+    "id": "Lleech",
+    "hatred": [
+      {
+        "id": "Slayer",
+        "reason": "If the Slayer shoots the Lleech's host, the host dies. "
+      },
+      {
+        "id": "Heretic",
+        "reason": "If the Lleech has poisoned the Heretic then the Lleech dies, the Heretic remains poisoned."
+      },
+	  {
+        "id": "Mastermind",
+        "reason": "If the Mastermind is alive and the Lleech's host dies by execution, the Lleech lives but loses their ability. "
+      }
+    ]
+  },
+  {
+    "id": "Vortox",
+    "hatred": [
+      {
+        "id": "Banshee",
+        "reason": "If the Vortox is in play and the Demon kills the Banshee, the players still learn that the Banshee has died."
+      }
+    ]
+  },
+  {
+    "id": "Legion",
+    "hatred": [
+      {
+        "id": "Preacher",
+        "reason": "If the Preacher chooses Legion, Legion keeps their ability, but the Preacher might learn they are Legion."
+      },
+      {
+        "id": "Engineer",
+        "reason": "Legion and the Engineer cannot both be in play at the start of the game. If the Engineer creates Legion, most players (including all evil players) become evil Legion."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "If Legion died by execution today, Legion keeps their ability, but the Minstrel might learn they are Legion."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "The Zealot might register as evil to Legion’s ability."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "If the Hatter dies and Legion is in play, nothing happens. If the Hatter dies and an evil player chooses Legion, all current evil players become Legion."
+      }
+    ]
+  },
+  {
+    "id": "Al-Hadikhia",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "If there are two living Al-Hadikhias, the Scarlet Woman Al-Hadikhia becomes the Scarlet Woman again."
+      },
+      {
+        "id": "Mastermind",
+        "reason": "If the Al-Hadikhia dies by execution, and the Mastermind is alive, the Al-Hadikhia chooses 3 good players tonight: if all 3 choose to live, evil wins. Otherwise, good wins."
+      }
+    ]
+  },
+  {
+    "id": "Fang Gu",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "If the Fang Gu chooses an Outsider and dies, the Scarlet Woman does not become the Fang Gu."
+      }
+    ]
+  },
+  {
+    "id": "Leviathan",
+    "hatred": [
+      {
+        "id": "Innkeeper",
+        "reason": "If Leviathan nominates and executes a player the Innkeeper chose, that player does not die."
+      },
+      {
+        "id": "Monk",
+        "reason": "If Leviathan nominates and executes the player the Monk chose, that player does not die."
+      },
+	  {
+        "id": "Soldier",
+        "reason": "If Leviathan nominates and executes the Soldier, the Soldier does not die."
+      },
+      {
+        "id": "Sage",
+        "reason": "If Leviathan is in play & the Sage dies by execution, they wake that night to use their ability. They are drunk if their nominator was good."
+      },
+      {
+        "id": "Farmer",
+        "reason": "If Leviathan is in play and a Farmer dies by execution, a good player becomes a Farmer that night."
+      },	  
+      {
+        "id": "Ravenkeeper",
+        "reason": "If Leviathan is in play & the Ravenkeeper dies by execution, they wake that night to use their ability. They are drunk if their nominator was good."
+      },
+      {
+        "id": "Mayor",
+        "reason": "If Leviathan is in play and no execution occurs on day 5, good wins."
+      },
+      {
+        "id": "Banshee",
+        "reason": "If Leviathan is in play, and the Banshee dies by execution, all players learn that the Banshee has died, and the Banshee gains their ability."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "If the Hatter dies on or after day 5, the Demon cannot choose Leviathan."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "After day 5, the Pit-Hag cannot choose Leviathan."
+      }
+    ]
+  },
+  {
+    "id": "Riot",
+    "hatred": [
+      {
+        "id": "Investigator",
+        "reason": "Riot registers as a Minion to the Investigator."
+      },
+      {
+        "id": "Clockmaker",
+        "reason": "Riot registers as a Minion to the Clockmaker."
+      },
+      {
+        "id": "Grandmother",
+        "reason": "If a Riot player nominates and kills the grandchild, the Grandmother dies too."
+      },
+      {
+        "id": "Preacher",
+        "reason": "Riot registers as a Minion to the Preacher."
+      },
+      {
+        "id": "King",
+        "reason": "If a Riot player nominates and kills the King and the Choirboy is alive, the Choirboy uses their ability tonight."
+      },
+      {
+        "id": "Flowergirl",
+        "reason": "Only one jinxed character can be in play."
+      },
+      {
+        "id": "Town Crier",
+        "reason": "Riot registers as a Minion to the Town Crier."
+      },
+      {
+        "id": "Undertaker",
+        "reason": "Players that die by nomination register as executed to the Undertaker."
+      },
+      {
+        "id": "Innkeeper",
+        "reason": "If a Riot player nominates an Innkeeper-protected player, the protected-player does not die."
+      },
+      {
+        "id": "Monk",
+        "reason": "If a Riot player nominates a Monk-protected player, the protected-player does not die."
+      },
+      {
+        "id": "Exorcist",
+        "reason": "Only one jinxed character can be in play."
+      },
+      {
+        "id": "Engineer",
+        "reason": "Riot and the Engineer cannot both be in play at the start of the game. If the Engineer creates Riot, the evil players become Riot."
+      },
+      {
+        "id": "Soldier",
+        "reason": "If a Riot player nominates the Soldier, the Soldier does not die."
+      },
+      {
+        "id": "Pacifist",
+        "reason": "Players that die by nomination register as executed to the Pacifist."
+      },
+      {
+        "id": "Sage",
+        "reason": "If a Riot player nominates and kills a Sage, the Sage uses their ability tonight."
+      },
+      {
+        "id": "Farmer",
+        "reason": "If a Riot player nominates and kills a Farmer, the Farmer uses their ability tonight."
+      },
+      {
+        "id": "Ravenkeeper",
+        "reason": "If a Riot player nominates and kills the Ravenkeeper, the Ravenkeeper uses their ability tonight."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "Only one jinxed character can be in play."
+      },
+      {
+        "id": "Cannibal",
+        "reason": "Players that die by nomination register as executed to the Cannibal."
+      },
+      {
+        "id": "Mayor",
+        "reason": "If the third day begins with just three players alive, the players may choose (as a group) not to nominate at all. If so (and a Mayor is alive) the Mayor's team wins."
+      },
+      {
+        "id": "Banshee",
+        "reason": "If Riot nominates and kills the Banshee, all players learn that the Banshee has died, and the Banshee may nominate two players immediately."
+      },
+      {
+        "id": "Snitch",
+        "reason": "If the Snitch is in play, each Riot player gets an extra three bluffs."
+      },
+      {
+        "id": "Butler",
+        "reason": "The Butler cannot nominate their master."
+      },
+      {
+        "id": "Saint",
+        "reason": "If a good player nominates and kills the Saint, the Saint's team loses."
+      },
+      {
+        "id": "Zealot",
+        "reason": "If you are nominated, you must nominate again, even if dead."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Riot registers as a Minion to the Damsel."
+      },
+	  {
+        "id": "Golem",
+        "reason": "If The Golem nominates Riot, the Riot player does not die."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "If the Hatter dies, Riot is in play and a Riot chooses a different Demon, a normal evil team is created from the Riot players. If the Hatter dies and the Demon chooses Riot, Minions become Riot too."
+      },
+      {
+        "id": "Devil's Advocate",
+        "reason": "Players that die by nomination register as executed to the Devil's Advocate."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "If the Pit-Hag creates Riot, all evil players become Riot. If the Pit-Hag creates Riot after day 3, the game continues for one more day."
       }
     ]
   }

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -358,14 +358,6 @@
     "id": "Organ Grinder",
     "hatred": [
       {
-        "id": "Preacher",
-        "reason": "If the Preacher removes the Organ Grinder ability, the Organ Grinder keeps their ability but the Preacher keeps their eyes open when voting."
-      },
-	  {
-        "id": "Minstrel",
-        "reason": "If the Minstrel makes everyone drunk, the Organ Grinder keeps their ability but the Minstrel keeps their eyes open when voting."
-      },
-      {
         "id": "Butler",
         "reason": "If the Organ Grinder is causing eyes closed voting, the Butler may raise their hand to vote but their vote is only counted if their master voted too."
       }
@@ -472,7 +464,7 @@
       },
       {
         "id": "Soldier",
-        "reason": "If the Kazali turns the Soldier into a Minion, the Soldier chooses which not-in-play Minion to become."
+        "reason": "The Kazali can choose that the Goon player is one of their evil Minions."
       },
       {
         "id": "Choirboy",

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -66,7 +66,7 @@
     "hatred": [
       {
         "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       }
     ]
   },
@@ -99,7 +99,7 @@
       },
       {
         "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       }
     ]
   },
@@ -175,7 +175,7 @@
       },
       {
         "id": "Heretic",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       }
     ]
   },
@@ -282,7 +282,7 @@
       },
       {
         "id": "Riot",
-        "reason": "If the Summoner creates Riot, the chosen player and all evil players become Riot. The chosen player must be one of the Summoner's good living neighbours."
+        "reason": "If the Summoner creates Riot, all Minions also become Riot."
       }
     ]
   },
@@ -305,6 +305,15 @@
     ]
   },
   {
+    "id": "Mastermind",
+    "hatred": [
+      {
+        "id": "Al-Hadikhia",
+        "reason": "If the Al-Hadikhia dies by execution, and the Mastermind is alive, the Al-Hadikhia chooses 3 good players tonight: if all 3 choose to live, evil wins. Otherwise, good wins."
+      }
+    ]
+  },
+  {
     "id": "Scarlet Woman",
     "hatred": [
       {
@@ -322,7 +331,7 @@
       },
       {
         "id": "Preacher",
-        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
+        "reason": "If the Vizier loses their ability, they learn this. If the Vizier is executed while they have their ability, their team wins."
       },
       {
         "id": "Alsaahir",
@@ -330,7 +339,7 @@
       },
       {
         "id": "Courtier",
-        "reason": "If the Vizier loses their ability, they learn this and if the Vizier is executed while they have their ability, their team wins."
+        "reason": "If the Vizier loses their ability, they learn this. If the Vizier is executed while they have their ability, their team wins."
       },
       {
         "id": "Alchemist",
@@ -409,7 +418,7 @@
       },
 	  {
         "id": "Heretic",
-        "reason": "The Baron might only add one Outsider, not two."
+        "reason": "The Baron might only add 1 Outsider, not 2."
       }
     ]
   },
@@ -484,10 +493,6 @@
     "id": "Al-Hadikhia",
     "hatred": [
       {
-        "id": "Mastermind",
-        "reason": "If the Al-Hadikhia dies by execution, and the Mastermind is alive, the Al-Hadikhia chooses 3 good players tonight: if all 3 choose to live, evil wins. Otherwise, good wins."
-      },
-      {
         "id": "Scarlet Woman",
         "reason": "If there are two living Al-Hadikhias, the Scarlet Woman Al-Hadikhia becomes the Scarlet Woman again."
       }
@@ -541,7 +546,7 @@
     "hatred": [
       {
         "id": "Slayer",
-        "reason": "If the Slayer shoots the Lleech's host, the host dies. "
+        "reason": "If the Slayer shoots the Lleech's host, the host dies."
       },
       {
         "id": "Heretic",
@@ -549,7 +554,7 @@
       },
 	  {
         "id": "Mastermind",
-        "reason": "If the Mastermind is alive and the Lleech's host dies by execution, the Lleech lives but loses their ability. "
+        "reason": "If the Mastermind is alive and the Lleech's host dies by execution, the Lleech lives but loses their ability."
       }
     ]
   },
@@ -570,7 +575,7 @@
       },
       {
         "id": "Farmer",
-        "reason": "If Leviathan is in play and a Farmer dies by execution, a good player becomes a Farmer that night."
+        "reason": "If Leviathan is in play & a Farmer dies by execution, a good player becomes a Farmer that night."
       },	  
       {
         "id": "Ravenkeeper",
@@ -623,7 +628,7 @@
       },
       {
         "id": "Flowergirl",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       },
       {
         "id": "Town Crier",
@@ -639,11 +644,11 @@
       },
       {
         "id": "Monk",
-        "reason": "If a Riot player nominates a Monk-protected player, the protected-player does not die."
+        "reason": "If a Riot player nominates and kills the Monk-protected-player, the Monk-protected-player does not die."
       },
       {
         "id": "Exorcist",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       },
       {
         "id": "Engineer",
@@ -659,7 +664,7 @@
       },
       {
         "id": "Minstrel",
-        "reason": "Only one jinxed character can be in play."
+        "reason": "Only 1 jinxed character can be in play."
       },
       {
         "id": "Farmer",
@@ -687,7 +692,7 @@
       },
       {
         "id": "Butler",
-        "reason": "The Butler cannot nominate their master."
+        "reason": "The Butler can not nominate their master."
       },
 	  {
         "id": "Golem",
@@ -711,7 +716,7 @@
       },
       {
         "id": "Snitch",
-        "reason": "If the Snitch is in play, each Riot player gets an extra three bluffs."
+        "reason": "If the Snitch is in play, each Riot player gets an extra 3 bluffs."
       },
       {
         "id": "Devil's Advocate",

--- a/src/store/locale/en/hatred.json
+++ b/src/store/locale/en/hatred.json
@@ -464,7 +464,7 @@
       },
       {
         "id": "Soldier",
-        "reason": "The Kazali can choose that the Goon player is one of their evil Minions."
+        "reason": "The Kazali can choose that the Soldier player is one of their evil Minions."
       },
       {
         "id": "Choirboy",
@@ -472,7 +472,7 @@
       },
       {
         "id": "Goon",
-        "reason": "If the Kazali chooses the Goon to become a Minion, remaining Minions choices are decided by the Storyteller."
+        "reason": "The Kazali can choose that the Goon player is one of their evil Minions."
       },
       {
         "id": "Marionette",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -453,10 +453,6 @@
       {
         "id": "Vizier",
         "reason": "Le Vizir peut mourir par exécution s'il a la garde du Bébé Monstre."
-      },
-	  {
-        "id": "Organ Grinder",
-        "reason": "Les votes contre l'Organiste barbare comptent si l'Organiste barbare a la garde du Bébé Monstre."
       }
     ]
   },

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -62,31 +62,6 @@
     ]
   },
   {
-    "id": "Widow",
-    "hatred": [
-      {
-        "id": "Alchemist",
-        "reason": "L'Alchimiste ne peut pas avoir la capacité de la Veuve."
-      },
-      {
-        "id": "Magician",
-        "reason": "Quand la Veuve regarde le Grimoire, les jetons du Démon et du Magicien sont retirés."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, la Veuve ne regarde pas le Grimoire avant la mort du Planteur de pavot."
-      },
-      {
-        "id": "Heretic",
-        "reason": "Seul un de ces personnages peut être en jeu."
-      },
-      {
-        "id": "Damsel",
-        "reason": "Si la Veuve est (ou a été) en jeu, la Demoiselle est empoisonnée."
-      }
-    ]
-  },
-  {
     "id": "Godfather",
     "hatred": [
       {
@@ -119,12 +94,130 @@
         "reason": "Si le Médecin de Peste aurait du donner la capacité d'Espion au Narrateur, un Sbire en vie gagne la capacité d'Espion en plus de sa propre capacité, et l'apprend."
       },
       {
+        "id": "Damsel",
+        "reason": "Si l'Espion est (ou a été) en jeu, la Demoiselle est empoisonnée."
+      },
+      {
         "id": "Heretic",
         "reason": "Seul un de ces personnages peut être en jeu."
+      }
+    ]
+  },
+  {
+    "id": "Cerenovus",
+    "hatred": [
+      {
+        "id": "Goblin",
+        "reason": "Le Cerenovus peut choisir de rendre un joueur persuadé d'être le Gobelin."
+      }
+    ]
+  },
+  {
+    "id": "Fearmonger",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Sbire en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
+      }
+    ]
+  },
+  {
+    "id": "Pit-Hag",
+    "hatred": [
+      {
+        "id": "Village Idiot",
+        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier peut en créer un nouveau. L'Idiot du Village ivre peut alors changer."
+      },
+      {
+        "id": "Cult Leader",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Gourou, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Goon",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Homme de main, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Ogre",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Ogre, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Politician",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Politicien, celui-ci ne peut pas devenir bon par sa capacité."
       },
       {
         "id": "Damsel",
-        "reason": "Si l'Espion est (ou a été) en jeu, la Demoiselle est empoisonnée."
+        "reason": "Si le Chaudronnier crée une Demoiselle, le Narrateur choisit quel joueur le devient"
+      },
+      {
+        "id": "Heretic",
+        "reason": "Le Chaudronnier ne peut pas créer un Hérétique."
+      }
+    ]
+  },
+  {
+    "id": "Widow",
+    "hatred": [
+      {
+        "id": "Alchemist",
+        "reason": "L'Alchimiste ne peut pas avoir la capacité de la Veuve."
+      },
+      {
+        "id": "Magician",
+        "reason": "Quand la Veuve regarde le Grimoire, les jetons du Démon et du Magicien sont retirés."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Si le Planteur de pavot est en jeu, la Veuve ne regarde pas le Grimoire avant la mort du Planteur de pavot."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Si la Veuve est (ou a été) en jeu, la Demoiselle est empoisonnée."
+      },
+      {
+        "id": "Heretic",
+        "reason": "Seul un de ces personnages peut être en jeu."
+      }
+    ]
+  },
+  {
+    "id": "Marionette",
+    "hatred": [
+      {
+        "id": "Balloonist",
+        "reason": "Si la Marionnette pense être l'Aéronaute, 1 Etranger a été ajouté."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "Si la Marionnette pense être le Chasseur, la Demoiselle a été ajoutée."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Quand le Planteur de pavot meurt, le Démon apprend qui est la Marionnette, mais la Marionnette n'apprend rien."
+      },
+      {
+        "id": "Plague Doctor",
+        "reason": "Si l'un des voisins du Démon est un Villageois ou Étranger et est vivant quand le Narrateur aurait du gagner la capacité de la Marionnette, ce joueur devient une Marionnette mauvaise. S'il y a déjà un joueur mauvais supplémentaire, cela n'arrive pas."
+      },
+      {
+        "id": "Damsel",
+        "reason": "La Marionnette n'apprend pas qu'une Demoiselle est en jeu."
+      },
+      {
+        "id": "Snitch",
+        "reason": "La Marionnette n'apprend pas 3 personnages qui ne sont pas en jeu. Le Démon en apprend 3 suplémentaires à la place."
+      },
+      {
+        "id": "Lil' Monsta",
+        "reason": "La Marionnette est voisine d'un Sbire, pas du Démon. La Marionnette n'est pas réveillée pour décider qui a la garde du Bébé Monstre, et n'apprend pas qu'elle est Marionnette si elle devient baby-sitter."
+      }
+    ]
+  },
+  {
+    "id": "Evil Twin",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "Le Narrateur ne peut pas gagner la capacité du Jumeau maléfique si le Médecin de Peste meurt."
       }
     ]
   },
@@ -168,92 +261,28 @@
         "reason": "La Marionnette est voisine de l'Invocateur. L'Invocateur sait qui est la Marionnette."
       },
       {
-        "id": "Kazali",
-        "reason": "L'Invocateur ne peut pas créer un Démon en jeu. Si l'Invocateur crée un Démon qui n'est pas en jeu, les morts cette nuit sont arbitraires."
-      },
-      {
         "id": "Pukka",
         "reason": "L'Invocateur peut choisir de changer un joueur en Pukka durant la deuxième nuit."
       },
       {
-        "id": "Lord of Typhon",
-        "reason": "Si l'Invocateur créé un Maître de Typhon, ce Maître de Typhon doit être voisin d'un Sbire. Son autre voisin devient un mauvais Sbire qui n'était pas en jeu."
+        "id": "Kazali",
+        "reason": "L'Invocateur ne peut pas créer un Démon en jeu. Si l'Invocateur crée un Démon qui n'est pas en jeu, les morts cette nuit sont arbitraires."
+      },
+      {
+        "id": "Zombuul",
+        "reason": "Si l'Invocateur change un joueur mort en Zombuul, le Narrateur traite ce joueur comme un Zombuul qui a été tué une fois."
       },
 	  {
         "id": "Legion",
         "reason": "Si l'Invocateur crée une Légion, la majorité des joueurs (y compris les joueurs mauvais) deviennent des Légions mauvaises."
       },
       {
-        "id": "Zombuul",
-        "reason": "Si l'Invocateur change un joueur mort en Zombuul, le Narrateur traite ce joueur comme un Zombuul qui a été tué une fois."
+        "id": "Lord of Typhon",
+        "reason": "Si l'Invocateur créé un Maître de Typhon, ce Maître de Typhon doit être voisin d'un Sbire. Son autre voisin devient un mauvais Sbire qui n'était pas en jeu."
       },
       {
         "id": "Riot",
         "reason": "Si l'Invocateur crée une Émeute, le joueur choisi et tous les mauvais deviennent des Émeutes. Le joueur choisi doit être un des bons voisins vivants de l'Invocateur."
-      }
-    ]
-  },
-  {
-    "id": "Cerenovus",
-    "hatred": [
-      {
-        "id": "Goblin",
-        "reason": "Le Cerenovus peut choisir de rendre un joueur persuadé d'être le Gobelin."
-      }
-    ]
-  },
-  {
-    "id": "Fearmonger",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Sbire en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
-      }
-    ]
-  },
-  {
-    "id": "Pit-Hag",
-    "hatred": [
-      {
-        "id": "Village Idiot",
-        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier peut en créer un nouveau. L'Idiot du Village ivre peut alors changer."
-      },
-      {
-        "id": "Cult Leader",
-        "reason": "Si le Chaudronnier change un joueur mauvais en Gourou, celui-ci ne peut pas devenir bon par sa capacité."
-      },
-      {
-        "id": "Ogre",
-        "reason": "Si le Chaudronnier change un joueur mauvais en Ogre, celui-ci ne peut pas devenir bon par sa capacité."
-      },
-      {
-        "id": "Goon",
-        "reason": "Si le Chaudronnier change un joueur mauvais en Homme de main, celui-ci ne peut pas devenir bon par sa capacité."
-      },
-      {
-        "id": "Heretic",
-        "reason": "Le Chaudronnier ne peut pas créer un Hérétique."
-      },
-      {
-        "id": "Damsel",
-        "reason": "Si le Chaudronnier crée une Demoiselle, le Narrateur choisit quel joueur le devient"
-      },
-      {
-        "id": "Politician",
-        "reason": "Si le Chaudronnier change un joueur mauvais en Politicien, celui-ci ne peut pas devenir bon par sa capacité."
-      }
-    ]
-  },
-  {
-    "id": "Baron",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "Si le Narrateur gagne la capacité du Baron, jusqu'à deux joueurs deviennent des Étrangers qui ne sont pas en jeu."
-      },
-	  {
-        "id": "Heretic",
-        "reason": "Il se peut que le Baron ajoute un Étranger au lieu de deux."
       }
     ]
   },
@@ -267,37 +296,20 @@
     ]
   },
   {
+    "id": "Boomdandy",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste est exécuté et que le Narrateur aurait du gagner une capacité d'Homme-bombe, la capacité d'Homme-bombe s'active immédiatement."
+      }
+    ]
+  },
+  {
     "id": "Scarlet Woman",
     "hatred": [
       {
         "id": "Plague Doctor",
         "reason": "Si le Médecin de Peste aurait du donner la capacité de Gourgandine au Narrateur, un Sbire en vie gagne la capacité de Gourgandine en plus de sa propre capacité, et l'apprend."
-      }
-    ]
-  },
-  {
-    "id": "Evil Twin",
-    "hatred": [
-      {
-        "id": "Plague Doctor",
-        "reason": "Le Narrateur ne peut pas gagner la capacité du Jumeau maléfique si le Médecin de Peste meurt."
-      }
-    ]
-  },
-  {
-    "id": "Organ Grinder",
-    "hatred": [
-      {
-        "id": "Preacher",
-        "reason": "Si le Prêcheur retire sa capacité à l'Organiste barbare, l'Organiste barbare garde sa capacité mais le Prêcheur garde les yeux ouverts durant les votes."
-      },
-	  {
-        "id": "Minstrel",
-        "reason": "Si le Ménestrel rend tout le monde ivre, l'Organiste barbare garde sa capacité mais le Ménestrel garde les yeux ouverts durant les votes."
-      },
-      {
-        "id": "Butler",
-        "reason": "Si les votes ont lieu à bulletin secret à cause de l'Organiste barbare, le Majordome peut lever sa main mais son vote ne compte que si son maître la lève aussi."
       }
     ]
   },
@@ -329,12 +341,12 @@
         "reason": "Si le Vizir et le Magicien sont tous deux en jeu, le Démon n'apprend pas qui sont les Sbires."
       },
       {
-        "id": "Zealot",
-        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour le Vizir."
-      },
-      {
         "id": "Politician",
         "reason": "Il se peut que le Politicien apparaisse comme mauvais pour le Vizir."
+      },
+      {
+        "id": "Zealot",
+        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour le Vizir."
       },
       {
         "id": "Fearmonger",
@@ -343,44 +355,69 @@
     ]
   },
   {
-    "id": "Boomdandy",
+    "id": "Organ Grinder",
     "hatred": [
       {
-        "id": "Plague Doctor",
-        "reason": "Si le Médecin de Peste est exécuté et que le Narrateur aurait du gagner une capacité d'Homme-bombe, la capacité d'Homme-bombe s'active immédiatement."
+        "id": "Preacher",
+        "reason": "Si le Prêcheur retire sa capacité à l'Organiste barbare, l'Organiste barbare garde sa capacité mais le Prêcheur garde les yeux ouverts durant les votes."
+      },
+	  {
+        "id": "Minstrel",
+        "reason": "Si le Ménestrel rend tout le monde ivre, l'Organiste barbare garde sa capacité mais le Ménestrel garde les yeux ouverts durant les votes."
+      },
+      {
+        "id": "Butler",
+        "reason": "Si les votes ont lieu à bulletin secret à cause de l'Organiste barbare, le Majordome peut lever sa main mais son vote ne compte que si son maître la lève aussi."
       }
     ]
   },
   {
-    "id": "Marionette",
+    "id": "Boffin",
     "hatred": [
       {
-        "id": "Balloonist",
-        "reason": "Si la Marionnette pense être l'Aéronaute, il se peut qu'1 Etranger ait été ajouté."
+        "id": "Village Idiot",
+        "reason": "S'il y a moins de trois Idiots du Village, le Spécialiste peut donner au Démon la capacité de l'Idiot du Village."
       },
       {
-        "id": "Huntsman",
-        "reason": "Si la Marionnette pense être le Chasseur, la Demoiselle a été ajoutée."
+        "id": "Cult Leader",
+        "reason": "Si le Démon a la capacité du Gourou, il ne peut pas devenir bon par sa capacité."
       },
       {
-        "id": "Poppy Grower",
-        "reason": "Quand le Planteur de pavot meurt, le Démon apprend qui est la Marionnette, mais la Marionnette n'apprend rien."
+        "id": "Alchemist",
+        "reason": "Si l'Alchimiste a la capacité du Spécialiste, il n'apprend pas quelle est la capacité de bon du Démon."
       },
       {
-        "id": "Snitch",
-        "reason": "La Marionnette n'apprend pas 3 personnages qui ne sont pas en jeu. Le Démon en apprend 3 suplémentaires à la place."
+        "id": "Goon",
+        "reason": "Si le Démon a la capacité de l'Homme de main, il ne peut pas devenir bon par sa capacité."
       },
+      {
+        "id": "Ogre",
+        "reason": "Le Démon ne peut pas avoir la capacité de l'Ogre."
+      },
+      {
+        "id": "Drunk",
+        "reason": "Si le Démon devrait avoir la capacité de l'Ivrogne, le Spécialiste choisit un joueur Villageois qui aura cette capacité à sa place."
+      },
+      {
+        "id": "Politician",
+        "reason": "Le Démon ne peut pas avoir la capacité du Politicien."
+      },
+	  {
+        "id": "Heretic",
+        "reason": "Le Démon ne peut pas avoir la capacité de l'Hérétique."
+      }
+    ]
+  },
+  {
+    "id": "Baron",
+    "hatred": [
       {
         "id": "Plague Doctor",
-        "reason": "Si l'un des voisins du Démon est un Villageois ou Étranger et est vivant quand le Narrateur aurait du gagner la capacité de la Marionnette, ce joueur devient une Marionnette mauvaise. S'il y a déjà un joueur mauvais supplémentaire, cela n'arrive pas."
+        "reason": "Si le Narrateur gagne la capacité du Baron, jusqu'à deux joueurs deviennent des Étrangers qui ne sont pas en jeu."
       },
-      {
-        "id": "Damsel",
-        "reason": "La Marionnette n'apprend pas qu'une Demoiselle est en jeu."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "La Marionnette est voisine d'un Sbire, pas du Démon. La Marionnette n'est pas réveillée pour décider qui a la garde du Bébé Monstre, et n'apprend pas qu'elle est Marionnette si elle devient baby-sitter."
+	  {
+        "id": "Heretic",
+        "reason": "Il se peut que le Baron ajoute un Étranger au lieu de deux."
       }
     ]
   },
@@ -390,6 +427,35 @@
       {
         "id": "Exorcist",
         "reason": "Si l'Exorciste désigne le Yaggablabla, la capacité du Yaggablabla ne tue personne cette nuit."
+      }
+    ]
+  },
+  {
+    "id": "Lil' Monsta",
+    "hatred": [
+      {
+        "id": "Magician",
+        "reason": "Chaque nuit, le Magicien choisit un rôle de Sbire : si ce Sbire et le Bébé monstre sont vivants, ce Sbire a la garde du Bébé monstre."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Si le Planteur de pavot est en jeu, les Sbires ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter."
+      },
+      {
+        "id": "Hatter",
+        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et a la garde du Bébé monstre cette nuit."
+      },
+      {
+        "id": "Scarlet Woman",
+        "reason": "S'il y a au moins 5 joueurs en vie au moment de la mort du baby-sitter, la Gourgandine récupére la garde du Bébé Monstre cette nuit."
+      },
+      {
+        "id": "Vizier",
+        "reason": "Le Vizir peut mourir par exécution s'il a la garde du Bébé Monstre."
+      },
+	  {
+        "id": "Organ Grinder",
+        "reason": "Les votes contre l'Organiste barbare comptent si l'Organiste barbare a la garde du Bébé Monstre."
       }
     ]
   },
@@ -421,33 +487,60 @@
         "reason": "Si le Kazali veut créer une Marionnette, il doit choisir l'un de ses voisins."
       }
     ]
-  },  
+  },
   {
-    "id": "Lil' Monsta",
+    "id": "Al-Hadikhia",
     "hatred": [
       {
-        "id": "Magician",
-        "reason": "Chaque nuit, le Magicien choisit un rôle de Sbire : si ce Sbire et le Bébé monstre sont vivants, ce Sbire a la garde du Bébé monstre."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, les Sbires ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter."
-      },
-      {
-        "id": "Hatter",
-        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et a la garde du Bébé monstre cette nuit."
+        "id": "Mastermind",
+        "reason": "Si l'Al-Hadikhia meurt par exécution, et si le Cerveau est en vie, l'Al-Hadikhia désigne trois joueurs bons cette nuit. Si tous choisit de vivre, les mauvais gagnent ; sinon, les bons gagnent."
       },
       {
         "id": "Scarlet Woman",
-        "reason": "S'il y a au moins 5 joueurs en vie au moment de la mort du baby-sitter, la Gourgandine récupére la garde du Bébé Monstre cette nuit."
-      },
-	  {
-        "id": "Organ Grinder",
-        "reason": "Les votes contre l'Organiste barbare comptent si l'Organiste barbare a la garde du Bébé Monstre."
+        "reason": "S'il y a deux Al-Hadikhias en vie, la Gourgandine devenue Al-Hadikhia redevient Gourgandine."
+      }
+    ]
+  },
+  {
+    "id": "Vortox",
+    "hatred": [
+      {
+        "id": "Banshee",
+        "reason": "Même si le Vortox est en jeu quand le Démon tue la Banshee, les joueurs apprennent que la Banshee est morte."
+      }
+    ]
+  },
+  {
+    "id": "Fang Gu",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "Si le Fang Gu désigne un Étranger et meurt, La Gourgandine ne devient pas Fang Gu ."
+      }
+    ]
+  },
+  {
+    "id": "Legion",
+    "hatred": [
+      {
+        "id": "Preacher",
+        "reason": "Si le Prêcheur désigne une Légion, la Légion garde sa capacité, mais il se peut que le Prêcheur apprenne que ce joueur est une Légion."
       },
       {
-        "id": "Vizier",
-        "reason": "Le Vizir peut mourir par exécution s'il a la garde du Bébé Monstre."
+        "id": "Engineer",
+        "reason": "La Légion et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. Si l'Ingénieur crée une Légion, la majorité des joueurs (y compris tous les joueurs mauvais) deviennent des Légions mauvaises."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "Si une Légion meurt par exécution, la Légion garde sa capacité, mais il se peut que le Ménestrel apprenne que ce joueur est une Légion."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "Si le Chapelier meurt alors que la Légion est en jeu, rien ne se passe. Si le Chapelier meurt et qu'un mauvais choisit de devenir Légion, tous les joueurs mauvais deviennent Légion."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour la capacité de la Légion."
       }
     ]
   },
@@ -469,62 +562,6 @@
     ]
   },
   {
-    "id": "Vortox",
-    "hatred": [
-      {
-        "id": "Banshee",
-        "reason": "Même si le Vortox est en jeu quand le Démon tue la Banshee, les joueurs apprennent que la Banshee est morte."
-      }
-    ]
-  },
-  {
-    "id": "Legion",
-    "hatred": [
-      {
-        "id": "Preacher",
-        "reason": "Si le Prêcheur désigne une Légion, la Légion garde sa capacité, mais il se peut que le Prêcheur apprenne que ce joueur est une Légion."
-      },
-      {
-        "id": "Engineer",
-        "reason": "La Légion et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. Si l'Ingénieur crée une Légion, la majorité des joueurs (y compris tous les joueurs mauvais) deviennent des Légions mauvaises."
-      },
-      {
-        "id": "Minstrel",
-        "reason": "Si une Légion meurt par exécution, la Légion garde sa capacité, mais il se peut que le Ménestrel apprenne que ce joueur est une Légion."
-      },
-	  {
-        "id": "Zealot",
-        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour la capacité de la Légion."
-      },
-	  {
-        "id": "Hatter",
-        "reason": "Si le Chapelier meurt alors que la Légion est en jeu, rien ne se passe. Si le Chapelier meurt et qu'un mauvais choisit de devenir Légion, tous les joueurs mauvais deviennent Légion."
-      }
-    ]
-  },
-  {
-    "id": "Al-Hadikhia",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "S'il y a deux Al-Hadikhias en vie, la Gourgandine devenue Al-Hadikhia redevient Gourgandine."
-      },
-      {
-        "id": "Mastermind",
-        "reason": "Si l'Al-Hadikhia meurt par exécution, et si le Cerveau est en vie, l'Al-Hadikhia désigne trois joueurs bons cette nuit. Si tous choisit de vivre, les mauvais gagnent ; sinon, les bons gagnent."
-      }
-    ]
-  },
-  {
-    "id": "Fang Gu",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "Si le Fang Gu désigne un Étranger et meurt, La Gourgandine ne devient pas Fang Gu ."
-      }
-    ]
-  },
-  {
     "id": "Leviathan",
     "hatred": [
       {
@@ -540,10 +577,6 @@
         "reason": "Si le Léviathan accuse et exécute le Soldat, le Soldat ne meurt pas."
       },
       {
-        "id": "Sage",
-        "reason": "Si le Léviathan est en jeu et que le Sage meurt par execution, il se réveille cette nuit pour utiliser sa capacité. Il est ivre si son accusateur était bon."
-      },
-      {
         "id": "Farmer",
         "reason": "Si le Léviathan est en jeu et qu'un Fermier meurt par éxécution, un joueur bon devient Fermier cette nuit."
       },	  
@@ -552,14 +585,18 @@
         "reason": "Si le Léviathan est en jeu et que l'Ami des corbeaux meurt par exécution, il se réveille cette nuit pour utiliser sa capacité. Il est ivre si son accusateur était bon."
       },
       {
-        "id": "Mayor",
-        "reason": "Si le Léviathan est en jeu et qu'il n'y a pas d'exécution le cinquième jour, les bons gagnent."
+        "id": "Sage",
+        "reason": "Si le Léviathan est en jeu et que le Sage meurt par execution, il se réveille cette nuit pour utiliser sa capacité. Il est ivre si son accusateur était bon."
       },
       {
         "id": "Banshee",
         "reason": "Si le Léviathan est en jeu, et si la Banshee meurt par exécution, tous les joueurs apprennent que la Banshee est morte, et la Banshee acquiert sa capacité."
       },
 	  {
+        "id": "Mayor",
+        "reason": "Si le Léviathan est en jeu et qu'il n'y a pas d'exécution le cinquième jour, les bons gagnent."
+      },
+      {
         "id": "Hatter",
         "reason": "Si le Chapelier est mort durant ou après le jour 5, le Démon ne peut pas choisir de devenir Léviathan."
       },
@@ -625,12 +662,12 @@
         "reason": "Si un joueur des Émeutes accuse le Soldat, le Soldat ne meurt pas."
       },
       {
-        "id": "Pacifist",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Pacifiste."
+        "id": "Cannibal",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Cannibale."
       },
       {
-        "id": "Sage",
-        "reason": "Si un joueur des Émeutes accuse et tue le Sage, le Sage utilise sa capacité cette nuit."
+        "id": "Minstrel",
+        "reason": "Seul un de ces personnages peut être en jeu."
       },
       {
         "id": "Farmer",
@@ -641,32 +678,36 @@
         "reason": "Si un joueur des Émeutes accuse et tue l'Ami des corbeaux, l'Ami des corbeaux utilise sa capacité cette nuit."
       },
       {
-        "id": "Minstrel",
-        "reason": "Seul un de ces personnages peut être en jeu."
-      },
-      {
-        "id": "Cannibal",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Cannibale."
-      },
-      {
-        "id": "Mayor",
-        "reason": "Si le 3ème jour commence avec seulement 3 joueurs en vie, les joueurs peuvent (collectivement) décider de ne pas accuser. S'il le font (et si le Maire est en vie) l'équipe du Maire gagne."
+        "id": "Sage",
+        "reason": "Si un joueur des Émeutes accuse et tue le Sage, le Sage utilise sa capacité cette nuit."
       },
       {
         "id": "Banshee",
         "reason": "Si un joueur des Émeutes accuse et tue la Banshee, tous les joueurs apprennent que la Banshee est morte, et la Banshee peut immédiatement accuser deux joueurs."
       },
       {
-        "id": "Snitch",
-        "reason": "Si le Cafteur est en jeu, chaque joueur des Émeutes reçoit 3 bluffs supplémentaires."
+        "id": "Mayor",
+        "reason": "Si le 3ème jour commence avec seulement 3 joueurs en vie, les joueurs peuvent (collectivement) décider de ne pas accuser. S'il le font (et si le Maire est en vie) l'équipe du Maire gagne."
+      },
+      {
+        "id": "Pacifist",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Pacifiste."
       },
       {
         "id": "Butler",
         "reason": "Le Majordome ne peut pas accuser son maître."
       },
+	  {
+        "id": "Golem",
+        "reason": "Si le Golem accuse une Émeute, ce joueur ne meurt pas."
+      },
       {
         "id": "Saint",
         "reason": "Si un joueur bon accuse et tue le Saint, l'équipe du Saint perd."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Sbires. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Sbires deviennent des Émeutes aussi."
       },
       {
         "id": "Zealot",
@@ -676,13 +717,9 @@
         "id": "Damsel",
         "reason": "Les Émeutes apparaîssent comme des Sbires pour la Demoiselle."
       },
-	  {
-        "id": "Golem",
-        "reason": "Si le Golem accuse une Émeute, ce joueur ne meurt pas."
-      },
-	  {
-        "id": "Hatter",
-        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Sbires. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Sbires deviennent des Émeutes aussi."
+      {
+        "id": "Snitch",
+        "reason": "Si le Cafteur est en jeu, chaque joueur des Émeutes reçoit 3 bluffs supplémentaires."
       },
       {
         "id": "Devil's Advocate",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -356,7 +356,7 @@
     "hatred": [
       {
         "id": "Balloonist",
-        "reason": "Si la Marionnette pense être l'Aéronaute, 1 Etranger a été ajouté."
+        "reason": "Si la Marionnette pense être l'Aéronaute, il se peut qu'1 Etranger ait été ajouté."
       },
       {
         "id": "Huntsman",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -184,7 +184,7 @@
     "hatred": [
       {
         "id": "Balloonist",
-        "reason": "Si la Marionnette pense être l'Aéronaute, 1 Etranger a été ajouté."
+        "reason": "Si la Marionnette pense être l'Aéronaute, il se peut qu'1 Etranger ait été ajouté."
       },
       {
         "id": "Huntsman",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -4,122 +4,7 @@
     "hatred": [
       {
         "id": "Mathematician",
-        "reason": "La femme de chambre apprend si le Mathématicien va se réveiller, même si elle se réveille avant lui. "
-      }
-    ]
-  },
-  {
-    "id": "Butler",
-    "hatred": [
-      {
-        "id": "Cannibal",
-        "reason": "Si le Cannibale gagne la capacité du Majordome, il l'apprend. "
-      }
-    ]
-  },
-  {
-    "id": "Lunatic",
-    "hatred": [
-      {
-        "id": "Mathematician",
-        "reason": "Le Mathématicien apprend si l'Aliéné attaque des joueurs différents du véritable Démon. "
-      }
-    ]
-  },
-  {
-    "id": "Pit-Hag",
-    "hatred": [
-      {
-        "id": "Heretic",
-        "reason": "Le Chaudronnier ne peut pas créer un Hérétique. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "Si le Chaudronnier crée une Demoiselle, c'est le Narrateur qui choisit quel joueur le devient. "
-      },
-      {
-        "id": "Politician",
-        "reason": "Un Chaudronnier ne peut pas créer un Politicien mauvais. "
-      },
-      {
-        "id": "Village Idiot",
-        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier a le droit d'en créer un nouveau. L'Idiot du Village ivre peut alors changer."
-      }
-    ]
-  },
-  {
-    "id": "Cerenovus",
-    "hatred": [
-      {
-        "id": "Goblin",
-        "reason": "Le Cerenovus peut choisir de rendre un joueur persuadé d'être le Gobelin. "
-      }
-    ]
-  },
-  {
-    "id": "Leviathan",
-    "hatred": [
-      {
-        "id": "Soldier",
-        "reason": "Si une accusation par le Léviathan aboutit à l'exécution du Soldat, le Soldat ne meurt pas. "
-      },
-      {
-        "id": "Monk",
-        "reason": "Si une accusation par le Léviathan aboutit à l'éxécution d'un joueur protégé par le Moine, ce joueur ne meurt pas. "
-      },
-      {
-        "id": "Innkeeper",
-        "reason": "Si une accusation par le Léviathan aboutit à l'éxécution d'un joueur protégé par l'Aubergiste, ce joueur ne meurt pas. "
-      },
-      {
-        "id": "Ravenkeeper",
-        "reason": "Si le Léviathan est en jeu et que l'Ami des corbeaux meurt par exécution, il se réveille cette nuit pour utiliser son pouvoir. "
-      },
-      {
-        "id": "Sage",
-        "reason": "Si le Léviathan est en jeu et que le Sage meurt par execution, il se réveille cette nuit pour utiliser son pouvoir. "
-      },
-      {
-        "id": "Farmer",
-        "reason": "Si le Léviathan est en jeu et qu'un Fermier meurt par éxécution, un joueur bon devient un Fermier cette nuit. "
-      },
-      {
-        "id": "Mayor",
-        "reason": "Si le Léviathan est en jeu et qu'il n'y a pas d'exécution le cinquième jour, les bons gagnent. "
-      },
-      {
-        "id": "Pit-Hag",
-        "reason": "Après le jour 5, le Chaudronnier ne peut pas créer de Léviathan."
-      }
-    ]
-  },
-  {
-    "id": "Al-Hadikhia",
-    "hatred": [
-      {
-        "id": "Scarlet Woman",
-        "reason": "S'il y a deux Al-Hadikhias en vie, la Gourgandine devenue Al-Hadikhia redevient Gourgandine. "
-      },
-      {
-        "id": "Mastermind",
-        "reason": "Un seul personnage maudit peut être en jeu à la fois. Les joueurs mauvais commencent la partie en sachant de quel joueur et quel rôle il s'agit. "
-      }
-    ]
-  },
-  {
-    "id": "Lil' Monsta",
-    "hatred": [
-      {
-        "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, Les Sbires ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter. "
-      },
-      {
-        "id": "Magician",
-        "reason": "Un seul personnage maudit peut être en jeu. "
-      },
-      {
-        "id": "Scarlet Woman",
-        "reason": "S'il y a 5 joueurs ou plus en vie et que le baby-sitter du Bébé Monstre meurt par exécution, la Gourgandine récupére le Bébé Monstre cette nuit. "
+        "reason": "La Femme de chambre apprend si le Mathématicien va se réveiller, même si elle se réveille avant lui."
       }
     ]
   },
@@ -128,54 +13,51 @@
     "hatred": [
       {
         "id": "Gambler",
-        "reason": "Si le Lycanthrope est en vie et que le Parieur se tue lui-même la nuit, aucun autre joueur ne peut mourir cette nuit. "
+        "reason": "Si le Lycanthrope est en vie et que le Parieur se tue lui-même durant la nuit, aucun autre joueur ne peut mourir cette nuit."
       }
     ]
   },
   {
-    "id": "Legion",
+    "id": "Philosopher",
     "hatred": [
       {
-        "id": "Engineer",
-        "reason": "La Légion et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. Si l'Ingénieur crée une Légion, la majorité des joueurs (y compris les joueurs mauvais) deviennent des Légions mauvaises. "
-      },
-      {
-        "id": "Preacher",
-        "reason": "Un seul personnage maudit peut être en jeu à la fois. "
+        "id": "Bounty Hunter",
+        "reason": "Si le Philosophe gagne la capacité du Mercenaire, il se peut qu'un Villageois devienne mauvais."
       }
     ]
   },
   {
-    "id": "Fang Gu",
+    "id": "Cannibal",
     "hatred": [
       {
-        "id": "Scarlet Woman",
-        "reason": "Si le Fang Gu désigne un étranger et meurt, La Gourgandine ne devient pas le Fang Gu . "
+        "id": "Juggler",
+        "reason": "Si le Jongleur a deviné des rôles durant son premier jour et est alors mort par exécution, le Cannibale apprend combien de rôles le Jongleur a deviné correctement."
+      },
+	  {
+        "id": "Butler",
+        "reason": "Si le Cannibale gagne la capacité du Majordome, il l'apprend."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "Si le Cannibale gagne la capacité du Fanatique, il l'apprend."
       }
     ]
   },
   {
-    "id": "Spy",
+    "id": "Ogre",
     "hatred": [
       {
-        "id": "Magician",
-        "reason": "Quand l'Espion regarde le grimoire, les jetons du Démon et du Magicien sont retirés. "
-      },
+        "id": "Recluse",
+        "reason": "Si le Reclus apparaît comme mauvais pour l'Ogre, l'Ogre apprend qu'il devient mauvais."
+      }
+    ]
+  },
+  {
+    "id": "Lunatic",
+    "hatred": [
       {
-        "id": "Alchemist",
-        "reason": "L'Alchimiste ne peut pas avoir la capacité de l'Espion. "
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, l'Espion ne regarde pas le Grimoire avant la mort du Planteur de pavot. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "Un seul personnage maudit peut être en jeu. "
-      },
-      {
-        "id": "Heretic",
-        "reason": "Un seul personnage maudit peut être en jeu. "
+        "id": "Mathematician",
+        "reason": "Le Mathématicien apprend si l'Aliéné attaque des joueur(s) différent(s) du véritable Démon."
       }
     ]
   },
@@ -183,24 +65,24 @@
     "id": "Widow",
     "hatred": [
       {
+        "id": "Alchemist",
+        "reason": "L'Alchimiste ne peut pas avoir la capacité de la Veuve."
+      },
+      {
         "id": "Magician",
-        "reason": "Quand la Veuve regarde le Grimoire, Les jetons du Démon et du Magicien sont retirés. "
+        "reason": "Quand la Veuve regarde le Grimoire, les jetons du Démon et du Magicien sont retirés."
       },
       {
         "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en jeu, La Veuve ne regarde pas le Grimoire avant la mort du Planteur de pavot. "
-      },
-      {
-        "id": "Alchemist",
-        "reason": "L'Alchimiste ne peut pas avoir la capacité de la Veuve. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "Un seul personnage maudit peut être en jeu. "
+        "reason": "Si le Planteur de pavot est en jeu, la Veuve ne regarde pas le Grimoire avant la mort du Planteur de pavot."
       },
       {
         "id": "Heretic",
-        "reason": "Un seul personnage maudit peut être en jeu. "
+        "reason": "Seul un de ces personnages peut être en jeu."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Si la Veuve est (ou a été) en jeu, la Demoiselle est empoisonnée."
       }
     ]
   },
@@ -209,7 +91,156 @@
     "hatred": [
       {
         "id": "Heretic",
-        "reason": "Un seul personnage maudit peut être en jeu. "
+        "reason": "Seul un de ces personnages peut être en jeu."
+      }
+    ]
+  },
+  {
+    "id": "Spy",
+    "hatred": [
+      {
+        "id": "Alchemist",
+        "reason": "L'Alchimiste ne peut pas avoir la capacité de l'Espion."
+      },
+      {
+        "id": "Magician",
+        "reason": "Quand l'Espion regarde le Grimoire, les jetons du Démon et du Magicien sont retirés."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Si le Planteur de pavot est en jeu, l'Espion ne regarde pas le Grimoire avant la mort du Planteur de pavot."
+      },
+      {
+        "id": "Ogre",
+        "reason": "L'Espion apparaît comme mauvais pour l'Ogre."
+      },
+	  {
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste aurait du donner la capacité d'Espion au Narrateur, un Sbire en vie gagne la capacité d'Espion en plus de sa propre capacité, et l'apprend."
+      },
+      {
+        "id": "Heretic",
+        "reason": "Seul un de ces personnages peut être en jeu."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Si l'Espion est (ou a été) en jeu, la Demoiselle est empoisonnée."
+      }
+    ]
+  },
+  {
+    "id": "Summoner",
+    "hatred": [
+      {
+        "id": "Clockmaker",
+        "reason": "Si l'Invocateur est en jeu, l'Horloger ne reçoit aucune info jusqu'à ce qu'un Démon soit créé."
+      },
+      {
+        "id": "Preacher",
+        "reason": "Si le Prêcheur désigne l'Invocateur durant la troisième nuit ou avant, l'Invocateur choisit quel Démon mais le Narrateur choisit quel joueur."
+      },
+      {
+        "id": "Engineer",
+        "reason": "Si l'Ingénieur retire l'Invocateur avant que celui-ci n'ait utilisé sa capacité, l'Invocateur utilise sa capacité immédiatement."
+      },
+      {
+        "id": "Courtier",
+        "reason": "Si l'Invocateur est ivre durant la troisième nuit, l'Invocateur choisit quel Démon mais le Narrateur choisit quel joueur."
+      },
+      {
+        "id": "Alchemist",
+        "reason": "Si un Alchimiste-Invocateur est en jeu, la partie commence avec un Démon, comme d'habitude. Si l'Alchimiste-Invocateur désigne un joueur, il le transforme en Démon mais ne change pas son alignement.""
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Si le Planteur de pavot est en vie lorsque l'Invocateur agit, l'Invocateur choisit quel Démon mais le Narrateur choisit quel joueur."
+      },
+      {
+        "id": "Hatter",
+        "reason": "L'Invocateur ne peut pas créer un Démon en jeu. Si l'Invocateur crée un Démon qui n'est pas en jeu, les morts cette nuit sont arbitraires."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "L'Invocateur ne peut pas créer un Démon en jeu. Si l'Invocateur crée un Démon qui n'est pas en jeu, les morts cette nuit sont arbitraires."
+      },
+      {
+        "id": "Marionette",
+        "reason": "La Marionnette est voisine de l'Invocateur. L'Invocateur sait qui est la Marionnette."
+      },
+      {
+        "id": "Kazali",
+        "reason": "L'Invocateur ne peut pas créer un Démon en jeu. Si l'Invocateur crée un Démon qui n'est pas en jeu, les morts cette nuit sont arbitraires."
+      },
+      {
+        "id": "Pukka",
+        "reason": "L'Invocateur peut choisir de changer un joueur en Pukka durant la deuxième nuit."
+      },
+      {
+        "id": "Lord of Typhon",
+        "reason": "Si l'Invocateur créé un Maître de Typhon, ce Maître de Typhon doit être voisin d'un Sbire. Son autre voisin devient un mauvais Sbire qui n'était pas en jeu."
+      },
+	  {
+        "id": "Legion",
+        "reason": "Si l'Invocateur crée une Légion, la majorité des joueurs (y compris les joueurs mauvais) deviennent des Légions mauvaises."
+      },
+      {
+        "id": "Zombuul",
+        "reason": "Si l'Invocateur change un joueur mort en Zombuul, le Narrateur traite ce joueur comme un Zombuul qui a été tué une fois."
+      },
+      {
+        "id": "Riot",
+        "reason": "Si l'Invocateur crée une Émeute, le joueur choisi et tous les mauvais deviennent des Émeutes. Le joueur choisi doit être un des bons voisins vivants de l'Invocateur."
+      }
+    ]
+  },
+  {
+    "id": "Cerenovus",
+    "hatred": [
+      {
+        "id": "Goblin",
+        "reason": "Le Cerenovus peut choisir de rendre un joueur persuadé d'être le Gobelin."
+      }
+    ]
+  },
+  {
+    "id": "Fearmonger",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Sbire en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
+      }
+    ]
+  },
+  {
+    "id": "Pit-Hag",
+    "hatred": [
+      {
+        "id": "Village Idiot",
+        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier peut en créer un nouveau. L'Idiot du Village ivre peut alors changer."
+      },
+      {
+        "id": "Cult Leader",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Gourou, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Ogre",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Ogre, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Goon",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Homme de main, celui-ci ne peut pas devenir bon par sa capacité."
+      },
+      {
+        "id": "Heretic",
+        "reason": "Le Chaudronnier ne peut pas créer un Hérétique."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Si le Chaudronnier crée une Demoiselle, le Narrateur choisit quel joueur le devient"
+      },
+      {
+        "id": "Politician",
+        "reason": "Si le Chaudronnier change un joueur mauvais en Politicien, celui-ci ne peut pas devenir bon par sa capacité."
       }
     ]
   },
@@ -217,167 +248,39 @@
     "id": "Baron",
     "hatred": [
       {
+        "id": "Plague Doctor",
+        "reason": "Si le Narrateur gagne la capacité du Baron, jusqu'à deux joueurs deviennent des Étrangers qui ne sont pas en jeu."
+      },
+	  {
         "id": "Heretic",
-        "reason": "Le Baron peut rajouter un Étranger au lieu de deux. "
+        "reason": "Il se peut que le Baron ajoute un Étranger au lieu de deux."
       }
     ]
   },
   {
-    "id": "Marionette",
+    "id": "Goblin",
     "hatred": [
       {
-        "id": "Lil' Monsta",
-        "reason": "La Marionnette est voisine d'un Sbire, pas du Démon. La Marionnette n'est pas réveillée pour décider qui baby-sitte le Bébé Monstre, et n'apprend pas qu'elle est Marionnette si elle devient baby-sitter. "
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "Quand le Planteur de pavot meurt, le Démon apprend qui est la Marionnette, mais la Marionnette n'apprend rien. "
-      },
-      {
-        "id": "Snitch",
-        "reason": "La Marionnette n'apprend pas 3 rôles qui ne sont pas en jeu. Le Démon en apprend 3 suplémentaires à la place. "
-      },
-      {
-        "id": "Balloonist",
-        "reason": "Si la Marionnette pense être l'Aéronaute, [+1 Etranger] "
-      },
-      {
-        "id": "Damsel",
-        "reason": "La Marionnette n'apprend pas qu'une Demoiselle est en jeu. "
-      },
-      {
-        "id": "Huntsman",
-        "reason": "Si la Marionnette pense être le Chasseur, [+ Demoiselle] "
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gobelin au Narrateur, un Sbire en vie gagne la capacité de Gobelin en plus de sa propre capacité, et l'apprend."
       }
     ]
   },
   {
-    "id": "Riot",
+    "id": "Scarlet Woman",
     "hatred": [
       {
-        "id": "Engineer",
-        "reason": "Les Émeutes et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. \nSi l'ingénieur crée une Émeute, tous les joueurs mauvais deviennent des Émeutes. "
-      },
-      {
-        "id": "Golem",
-        "reason": "Si le Golem accuse une Émeute, ce joueur ne meurt pas. "
-      },
-      {
-        "id": "Snitch",
-        "reason": "Si le Cafteur est en jeu, chaque joueur des Émeutes reçoit 3 bluffs supplémentaires. "
-      },
-      {
-        "id": "Saint",
-        "reason": "Si un joueur bon accuse et tue le Saint, l'équipe du Saint perd. "
-      },
-      {
-        "id": "Butler",
-        "reason": "Le Majordome ne peut pas accuser son maître. "
-      },
-      {
-        "id": "Pit-Hag",
-        "reason": "Si le Chaudronnier crée une Émeute, tous les joueurs mauvais deviennent des Émeutes. \nSi le Chaudronnier crée une Émeute après le jour 3, la partie continue pour un jour de plus. "
-      },
-      {
-        "id": "Mayor",
-        "reason": "Si le 3ème jour commence avec seulement 3 joueurs en vie, les joueurs peuvent collectivement décider de ne pas accuser. S'il le font (et si le Maire est en vie) l'équipe du Maire gagne. "
-      },
-      {
-        "id": "Monk",
-        "reason": "Si un joueur des Émeutes accuse un joueur protégé par le Moine, ce joueur ne meurt pas. "
-      },
-      {
-        "id": "Farmer",
-        "reason": "Si un joueur des Émeutes accuse et tue un Fermier, le Fermier utilise sa capacité cette nuit. "
-      },
-      {
-        "id": "Innkeeper",
-        "reason": "Si un joueur des Émeutes accuse un joueur protégé par l'Aubergiste, ce joueur ne meurt pas. "
-      },
-      {
-        "id": "Sage",
-        "reason": "Si un joueur des Émeutes accuse et tue le Sage, le Sage utilise son pouvoir cette nuit. "
-      },
-      {
-        "id": "Ravenkeeper",
-        "reason": "Si un joueur des Émeutes accuse et tue l'Ami des corbeaux, l'Ami des corbeaux utilise son pouvoir cette nuit. "
-      },
-      {
-        "id": "Soldier",
-        "reason": "Si un joueur des Émeutes accuse le Soldat, le Soldat ne meurt pas. "
-      },
-      {
-        "id": "Grandmother",
-        "reason": "Si un joueur des Émeutes accuse et tue le petit-fils, la Grand-mère meurt aussi. "
-      },
-      {
-        "id": "King",
-        "reason": "Si un joueur des Émeutes accuse et tue le Roi, et si l'Enfant de Choeur est en vie, l'Enfant de Choeur utilise son pouvoir cette nuit. "
-      },
-      {
-        "id": "Exorcist",
-        "reason": "Un seul personnage maudit peut être en jeu. "
-      },
-      {
-        "id": "Minstrel",
-        "reason": "Un seul personnage maudit peut être en jeu. "
-      },
-      {
-        "id": "Flowergirl",
-        "reason": "Un seul personnage maudit peut être en jeu. "
-      },
-      {
-        "id": "Undertaker",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Fossoyeur. "
-      },
-      {
-        "id": "Cannibal",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Cannibale. "
-      },
-      {
-        "id": "Pacifist",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Pacifiste. "
-      },
-      {
-        "id": "Devil's Advocate",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour l'Avocat du Diable. "
-      },
-      {
-        "id": "Investigator",
-        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Enquéteur. "
-      },
-      {
-        "id": "Clockmaker",
-        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Horloger. "
-      },
-      {
-        "id": "Town Crier",
-        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Crieur public. "
-      },
-      {
-        "id": "Damsel",
-        "reason": "Les Émeutes apparaîssent comme des Sbires pour la Demoiselle. "
-      },
-      {
-        "id": "Preacher",
-        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Prêcheur. "
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gourgandine au Narrateur, un Sbire en vie gagne la capacité de Gourgandine en plus de sa propre capacité, et l'apprend."
       }
     ]
   },
   {
-    "id": "Lleech",
+    "id": "Evil Twin",
     "hatred": [
       {
-        "id": "Mastermind",
-        "reason": "Si le Cerveau est en vie et que l'hôte de la Ssangssue meurt par execution, la Ssangssue survit mais perd son pouvoir. "
-      },
-      {
-        "id": "Slayer",
-        "reason": "Si le Tueur tire sur l'hôte de la Ssangssue, l'hôte meurt. "
-      },
-      {
-        "id": "Heretic",
-        "reason": "Si la Ssangssue a empoisonné l'Hérétique, et si elle meurt, alors l'Hérétique reste empoisonné. "
+        "id": "Plague Doctor",
+        "reason": "Le Narrateur ne peut pas gagner la capacité du Jumeau maléfique si le Médecin de Peste meurt."
       }
     ]
   },
@@ -385,24 +288,99 @@
     "id": "Organ Grinder",
     "hatred": [
       {
+        "id": "Preacher",
+        "reason": "Si le Prêcheur retire sa capacité à l'Organiste barbare, l'Organiste barbare garde sa capacité mais le Prêcheur garde les yeux ouverts durant les votes."
+      },
+	  {
+        "id": "Minstrel",
+        "reason": "Si le Ménestrel rend tout le monde ivre, l'Organiste barbare garde sa capacité mais le Ménestrel garde les yeux ouverts durant les votes."
+      },
+      {
         "id": "Butler",
         "reason": "Si les votes ont lieu à bulletin secret à cause de l'Organiste barbare, le Majordome peut lever sa main mais son vote ne compte que si son maître la lève aussi."
-      },
+      }
+    ]
+  },
+  {
+    "id": "Vizier",
+    "hatred": [
       {
-        "id": "Flowergirl",
-        "reason": "Si les votes ont eu lieu à bulletin secret, la Fleuriste apprend combien de fois le Démon a voté."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "Les votes contre l'Organiste barbare comptent si l'Organiste barbare baby-sitte le Bébé Monstre."
-      },
-      {
-        "id": "Minstrel",
-        "reason": "Un seul personnage maudit peut être en jeu à la fois. Les joueurs mauvais commencent la partie en sachant de quel joueur et quel rôle il s'agit."
+        "id": "Investigator",
+        "reason": "Si l'Enquêteur apprend qu'un Vizir est en jeu, la présence du Vizir n'est pas annoncée par le Narrateur."
       },
       {
         "id": "Preacher",
-        "reason": "Un seul personnage maudit peut être en jeu à la fois. Les joueurs mauvais commencent la partie en sachant de quel joueur et quel rôle il s'agit."
+        "reason": "Si le Vizir perd sa capacité, il l'apprend. Si le Vizir est exécuté alors qu'il a sa capacité, son équipe gagne."
+      },
+      {
+        "id": "Alsaahir",
+        "reason": "Si le Vizir est en jeu, l'Alsaahir doit également deviner quel(s) Démon(s) sont en jeu."
+      },
+      {
+        "id": "Courtier",
+        "reason": "Si le Vizir perd sa capacité, il l'apprend. Si le Vizir est exécuté alors qu'il a sa capacité, son équipe gagne."
+      },
+      {
+        "id": "Alchemist",
+        "reason": "Si l'Alchimiste a la capacité du Vizir, il peut exécuter si et seulement si au moins trois joueurs votent, peu importe leur alignement."
+      },
+	  {
+        "id": "Magician",
+        "reason": "Si le Vizir et le Magicien sont tous deux en jeu, le Démon n'apprend pas qui sont les Sbires."
+      },
+      {
+        "id": "Zealot",
+        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour le Vizir."
+      },
+      {
+        "id": "Politician",
+        "reason": "Il se peut que le Politicien apparaisse comme mauvais pour le Vizir."
+      },
+      {
+        "id": "Fearmonger",
+        "reason": "Le Vizir se réveille avec le Semeur de peur, et ne peut pas exécuter ce joueur."
+      }
+    ]
+  },
+  {
+    "id": "Boomdandy",
+    "hatred": [
+      {
+        "id": "Plague Doctor",
+        "reason": "Si le Médecin de Peste est exécuté et que le Narrateur aurait du gagner une capacité d'Homme-bombe, la capacité d'Homme-bombe s'active immédiatement."
+      }
+    ]
+  },
+  {
+    "id": "Marionette",
+    "hatred": [
+      {
+        "id": "Balloonist",
+        "reason": "Si la Marionnette pense être l'Aéronaute, 1 Etranger a été ajouté."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "Si la Marionnette pense être le Chasseur, la Demoiselle a été ajoutée."
+      },
+      {
+        "id": "Poppy Grower",
+        "reason": "Quand le Planteur de pavot meurt, le Démon apprend qui est la Marionnette, mais la Marionnette n'apprend rien."
+      },
+      {
+        "id": "Snitch",
+        "reason": "La Marionnette n'apprend pas 3 personnages qui ne sont pas en jeu. Le Démon en apprend 3 suplémentaires à la place."
+      },
+      {
+        "id": "Plague Doctor",
+        "reason": "Si l'un des voisins du Démon est un Villageois ou Étranger et est vivant quand le Narrateur aurait du gagner la capacité de la Marionnette, ce joueur devient une Marionnette mauvaise. S'il y a déjà un joueur mauvais supplémentaire, cela n'arrive pas."
+      },
+      {
+        "id": "Damsel",
+        "reason": "La Marionnette n'apprend pas qu'une Demoiselle est en jeu."
+      },
+      {
+        "id": "Lil' Monsta",
+        "reason": "La Marionnette est voisine d'un Sbire, pas du Démon. La Marionnette n'est pas réveillée pour décider qui a la garde du Bébé Monstre, et n'apprend pas qu'elle est Marionnette si elle devient baby-sitter."
       }
     ]
   },
@@ -416,98 +394,19 @@
     ]
   },
   {
-    "id": "Summoner",
-    "hatred": [
-      {
-        "id": "Alchemist",
-        "reason": "Si un Alchimiste-Invocateur est en jeu, la partie commence avec un Démon, comme d'habitude. Si l'Alchimiste-Invocateur désigne un joueur, il le transforme en Démon mais ne change pas son alignement."
-      },
-      {
-        "id": "Clockmaker",
-        "reason": "Si l'Invocateur est en jeu, l'Horloger ne reçoit aucune info jusqu'à ce qu'un Démon soit créé."
-      },
-      {
-        "id": "Poppy Grower",
-        "reason": "Si le Planteur de pavot est en vie lorsque l'Invocateur agit, l'Invocateur choisit un rôle de Démon, mais c'est le Narrateur qui choisit un joueur."
-      },
-      {
-        "id": "Marionette",
-        "reason": "La Marionnette est voisine de l'Invocateur. L'Invocateur sait qui est la Marionnette."
-      },
-      {
-        "id": "Kazali",
-        "reason": "Le Kazali ne peut pas créer un Invocateur."
-      },
-      {
-        "id": "Legion",
-        "reason": "Si l'Invocateur crée une Légion, la majorité des joueurs (y compris les joueurs mauvais) deviennent des Légions mauvaises."
-      },
-      {
-        "id": "Riot",
-        "reason": "Si l'Invocateur crée une Émeute, le joueur choisi et tous les mauvais deviennent des Émeutes. Le joueur choisi doit être un des bons voisins vivants de l'Invocateur."
-      }
-    ]
-  },
-  {
-    "id": "Vizier",
-    "hatred": [
-      {
-        "id": "Magician",
-        "reason": "Un seul personnage maudit peut être en jeu à la fois. Les joueurs mauvais commencent la partie en sachant de quel joueur et quel rôle il s'agit."
-      },
-      {
-        "id": "Alchemist",
-        "reason": "Si l'Alchimiste a la capacité du Vizir, il peut exécuter si et seulement si au moins 3 joueurs votent, peu importe leur alignement."
-      },
-      {
-        "id": "Courtier",
-        "reason": "Si le Vizir perd sa capacité, il l'apprend. Si le Vizir est exécuté alors qu'il a sa capacité, son équipe gagne."
-      },
-      {
-        "id": "Preacher",
-        "reason": "Si le Vizir perd sa capacité, il l'apprend. Si le Vizir est exécuté alors qu'il a sa capacité, son équipe gagne."
-      },
-      {
-        "id": "Investigator",
-        "reason": "Si l'Enquêteur apprend qu'un Vizir est en jeu, la présence du Vizir n'est pas annoncée publiquement."
-      },
-      {
-        "id": "Fearmonger",
-        "reason": "Le Vizir apprend quel joueur a été désigné par le Semeur de peur, et ne peut pas forcer l'exécution de ce joueur."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "Le Vizir peut mourir par exécution s'il a la garde du Bébé Monstre."
-      }
-    ]
-  },
-  {
-    "id": "Hatter",
-    "hatred": [
-      {
-        "id": "Legion",
-        "reason": "Si le Chapelier meurt alors qu'une Légion est en jeu, rien ne se passe. Si le Chapelier meurt et qu'un mauvais choisit de devenir Légion, tous les joueurs mauvais deviennent une Légion."
-      },
-      {
-        "id": "Leviathan",
-        "reason": "Si le Chapelier est mort durant ou après le cinquième jour, le Démon ne peut pas choisir de devenir Léviathan."
-      },
-      {
-        "id": "Lil' Monsta",
-        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et devient baby-sitter pour cette nuit."
-      },
-      {
-        "id": "Riot",
-        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Sbires. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Sbires deviennent des Émeutes aussi."
-      }
-    ]
-  },
-  {
     "id": "Kazali",
     "hatred": [
       {
         "id": "Bounty Hunter",
         "reason": "Un Villageois ne devient mauvais que si le Mercenaire est toujours en jeu après l'action du Kazali."
+      },
+      {
+        "id": "Huntsman",
+        "reason": "Si le Kazali transforme la Demoiselle en Sbire, et si le Chasseur est en jeu, un joueur bon devient Demoiselle."
+      },
+      {
+        "id": "Soldier",
+        "reason": "Si le Kazali transforme le Soldat en Sbire, le Soldat choisit quel Sbire non-distribué il devient."
       },
       {
         "id": "Choirboy",
@@ -518,49 +417,280 @@
         "reason": "Si le Kazali choisit de transformer l'Homme de main en Sbire, il devient ivre, et les Sbires restants sont choisis par le Narrateur sans prendre en compte les décisions du Kazali."
       },
       {
-        "id": "Huntsman",
-        "reason": "Si le Kazali transforme la Demoiselle en Sbire, et si le Chasseur est en jeu, un joueur bon devient Demoiselle."
-      },
-      {
         "id": "Marionette",
         "reason": "Si le Kazali veut créer une Marionnette, il doit choisir l'un de ses voisins."
       }
     ]
-  },
+  },  
   {
-    "id": "Plague Doctor",
+    "id": "Lil' Monsta",
     "hatred": [
       {
-        "id": "Baron",
-        "reason": "Si le Narrateur gagne la capacité du Baron, jusqu'à deux joueurs deviennent des Étrangers qui ne sont pas en jeu."
+        "id": "Magician",
+        "reason": "Chaque nuit, le Magicien choisit un rôle de Sbire : si ce Sbire et le Bébé monstre sont vivants, ce Sbire a la garde du Bébé monstre."
       },
       {
-        "id": "Boomdandy",
-        "reason": "Si le Médecin de Peste est exécuté et que le Narrateur aurait du gagner une capacité d'Homme-bombe, la capacité d'Homme-bombe s'active immédiatement."
+        "id": "Poppy Grower",
+        "reason": "Si le Planteur de pavot est en jeu, les Sbires ne se réveillent pas ensemble. Ils sont réveillés un par un jusqu'à ce que l'un d'entre eux décide d'être baby-sitter."
       },
       {
-        "id": "Evil Twin",
-        "reason": "Le Narrateur ne peut pas gagner une capacité de Jumeau maléfique si le Médecin de Peste meurt."
-      },
-      {
-        "id": "Fearmonger",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Semeur de peur au Narrateur, un Sbire en vie gagne la capacité de Semeur de peur en plus de sa propre capacité, et l'apprend."
-      },
-      {
-        "id": "Goblin",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gobelin au Narrateur, un Sbire en vie gagne la capacité de Gobelin en plus de sa propre capacité, et l'apprend."
+        "id": "Hatter",
+        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et a la garde du Bébé monstre cette nuit."
       },
       {
         "id": "Scarlet Woman",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité de Gourgandine au Narrateur, un Sbire en vie gagne la capacité de Gourgandine en plus de sa propre capacité, et l'apprend."
+        "reason": "S'il y a au moins 5 joueurs en vie au moment de la mort du baby-sitter, la Gourgandine récupére la garde du Bébé Monstre cette nuit."
+      },
+	  {
+        "id": "Organ Grinder",
+        "reason": "Les votes contre l'Organiste barbare comptent si l'Organiste barbare a la garde du Bébé Monstre."
       },
       {
-        "id": "Spy",
-        "reason": "Si le Médecin de Peste aurait du donner la capacité d'Espion au Narrateur, un Sbire en vie gagne la capacité d'Espion en plus de sa propre capacité, et l'apprend."
+        "id": "Vizier",
+        "reason": "Le Vizir peut mourir par exécution s'il a la garde du Bébé Monstre."
+      }
+    ]
+  },
+  {
+    "id": "Lleech",
+    "hatred": [
+      {
+        "id": "Slayer",
+        "reason": "Si le Tueur tire sur l'hôte de la Ssangssue, l'hôte meurt."
       },
       {
-        "id": "Marionette",
-        "reason": "Si l'un des voisins du Démon est un Villageois ou Étranger et est vivant quand le Médecin de Peste meurt, ce joueur devient une mauvaise Marionnette. S'il y a déjà un joueur mauvais de plus, cela n'arrive pas."
+        "id": "Heretic",
+        "reason": "Si la Ssangssue a empoisonné l'Hérétique, et si elle meurt, alors l'Hérétique reste empoisonné."
+      },
+	  {
+        "id": "Mastermind",
+        "reason": "Si le Cerveau est en vie et que l'hôte de la Ssangssue meurt par execution, la Ssangssue survit mais perd sa capacité."
+      }
+    ]
+  },
+  {
+    "id": "Vortox",
+    "hatred": [
+      {
+        "id": "Banshee",
+        "reason": "Même si le Vortox est en jeu quand le Démon tue la Banshee, les joueurs apprennent que la Banshee est morte."
+      }
+    ]
+  },
+  {
+    "id": "Legion",
+    "hatred": [
+      {
+        "id": "Preacher",
+        "reason": "Si le Prêcheur désigne une Légion, la Légion garde sa capacité, mais il se peut que le Prêcheur apprenne que ce joueur est une Légion."
+      },
+      {
+        "id": "Engineer",
+        "reason": "La Légion et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. Si l'Ingénieur crée une Légion, la majorité des joueurs (y compris tous les joueurs mauvais) deviennent des Légions mauvaises."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "Si une Légion meurt par exécution, la Légion garde sa capacité, mais il se peut que le Ménestrel apprenne que ce joueur est une Légion."
+      },
+	  {
+        "id": "Zealot",
+        "reason": "Il se peut que le Fanatique apparaisse comme mauvais pour la capacité de la Légion."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "Si le Chapelier meurt alors que la Légion est en jeu, rien ne se passe. Si le Chapelier meurt et qu'un mauvais choisit de devenir Légion, tous les joueurs mauvais deviennent Légion."
+      }
+    ]
+  },
+  {
+    "id": "Al-Hadikhia",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "S'il y a deux Al-Hadikhias en vie, la Gourgandine devenue Al-Hadikhia redevient Gourgandine."
+      },
+      {
+        "id": "Mastermind",
+        "reason": "Si l'Al-Hadikhia meurt par exécution, et si le Cerveau est en vie, l'Al-Hadikhia désigne trois joueurs bons cette nuit. Si tous choisit de vivre, les mauvais gagnent ; sinon, les bons gagnent."
+      }
+    ]
+  },
+  {
+    "id": "Fang Gu",
+    "hatred": [
+      {
+        "id": "Scarlet Woman",
+        "reason": "Si le Fang Gu désigne un Étranger et meurt, La Gourgandine ne devient pas Fang Gu ."
+      }
+    ]
+  },
+  {
+    "id": "Leviathan",
+    "hatred": [
+      {
+        "id": "Innkeeper",
+        "reason": "Si le Léviathan accuse et exécute un joueur protégé par l'Aubergiste, ce joueur ne meurt pas."
+      },
+      {
+        "id": "Monk",
+        "reason": "Si le Léviathan accuse et exécute un joueur protégé par le Moine, ce joueur ne meurt pas."
+      },
+	  {
+        "id": "Soldier",
+        "reason": "Si le Léviathan accuse et exécute le Soldat, le Soldat ne meurt pas."
+      },
+      {
+        "id": "Sage",
+        "reason": "Si le Léviathan est en jeu et que le Sage meurt par execution, il se réveille cette nuit pour utiliser sa capacité. Il est ivre si son accusateur était bon."
+      },
+      {
+        "id": "Farmer",
+        "reason": "Si le Léviathan est en jeu et qu'un Fermier meurt par éxécution, un joueur bon devient Fermier cette nuit."
+      },	  
+      {
+        "id": "Ravenkeeper",
+        "reason": "Si le Léviathan est en jeu et que l'Ami des corbeaux meurt par exécution, il se réveille cette nuit pour utiliser sa capacité. Il est ivre si son accusateur était bon."
+      },
+      {
+        "id": "Mayor",
+        "reason": "Si le Léviathan est en jeu et qu'il n'y a pas d'exécution le cinquième jour, les bons gagnent."
+      },
+      {
+        "id": "Banshee",
+        "reason": "Si le Léviathan est en jeu, et si la Banshee meurt par exécution, tous les joueurs apprennent que la Banshee est morte, et la Banshee acquiert sa capacité."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "Si le Chapelier est mort durant ou après le jour 5, le Démon ne peut pas choisir de devenir Léviathan."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "Après le jour 5, le Chaudronnier ne peut pas créer de Léviathan."
+      }
+    ]
+  },
+  {
+    "id": "Riot",
+    "hatred": [
+      {
+        "id": "Investigator",
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Enquêteur."
+      },
+      {
+        "id": "Clockmaker",
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour l'Horloger."
+      },
+      {
+        "id": "Grandmother",
+        "reason": "Si un joueur des Émeutes accuse et tue le petit-fils, la Grand-mère meurt aussi."
+      },
+      {
+        "id": "Preacher",
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Prêcheur."
+      },
+      {
+        "id": "King",
+        "reason": "Si un joueur des Émeutes accuse et tue le Roi, et si l'Enfant de Choeur est en vie, l'Enfant de Choeur utilise sa capacité cette nuit."
+      },
+      {
+        "id": "Flowergirl",
+        "reason": "Seul un de ces personnages peut être en jeu."
+      },
+      {
+        "id": "Town Crier",
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour le Crieur public."
+      },
+      {
+        "id": "Undertaker",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Fossoyeur"
+      },
+      {
+        "id": "Innkeeper",
+        "reason": "Si un joueur des Émeutes accuse un joueur protégé par l'Aubergiste, ce joueur ne meurt pas."
+      },
+      {
+        "id": "Monk",
+        "reason": "Si un joueur des Émeutes accuse un joueur protégé par le Moine, ce joueur ne meurt pas."
+      },
+      {
+        "id": "Exorcist",
+        "reason": "Seul un de ces personnages peut être en jeu."
+      },
+      {
+        "id": "Engineer",
+        "reason": "Les Émeutes et l'Ingénieur ne peuvent pas être tous les deux en jeu au début de la partie. Si l'ingénieur crée une Émeute, tous les joueurs mauvais deviennent des Émeutes."
+      },
+      {
+        "id": "Soldier",
+        "reason": "Si un joueur des Émeutes accuse le Soldat, le Soldat ne meurt pas."
+      },
+      {
+        "id": "Pacifist",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Pacifiste."
+      },
+      {
+        "id": "Sage",
+        "reason": "Si un joueur des Émeutes accuse et tue le Sage, le Sage utilise sa capacité cette nuit."
+      },
+      {
+        "id": "Farmer",
+        "reason": "Si un joueur des Émeutes accuse et tue un Fermier, le Fermier utilise sa capacité cette nuit."
+      },
+      {
+        "id": "Ravenkeeper",
+        "reason": "Si un joueur des Émeutes accuse et tue l'Ami des corbeaux, l'Ami des corbeaux utilise sa capacité cette nuit."
+      },
+      {
+        "id": "Minstrel",
+        "reason": "Seul un de ces personnages peut être en jeu."
+      },
+      {
+        "id": "Cannibal",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Cannibale."
+      },
+      {
+        "id": "Mayor",
+        "reason": "Si le 3ème jour commence avec seulement 3 joueurs en vie, les joueurs peuvent (collectivement) décider de ne pas accuser. S'il le font (et si le Maire est en vie) l'équipe du Maire gagne."
+      },
+      {
+        "id": "Banshee",
+        "reason": "Si un joueur des Émeutes accuse et tue la Banshee, tous les joueurs apprennent que la Banshee est morte, et la Banshee peut immédiatement accuser deux joueurs."
+      },
+      {
+        "id": "Snitch",
+        "reason": "Si le Cafteur est en jeu, chaque joueur des Émeutes reçoit 3 bluffs supplémentaires."
+      },
+      {
+        "id": "Butler",
+        "reason": "Le Majordome ne peut pas accuser son maître."
+      },
+      {
+        "id": "Saint",
+        "reason": "Si un joueur bon accuse et tue le Saint, l'équipe du Saint perd."
+      },
+      {
+        "id": "Zealot",
+        "reason": "Si le Fanatique est accusé, il doit accuser lui aussi, même s'il est mort."
+      },
+      {
+        "id": "Damsel",
+        "reason": "Les Émeutes apparaîssent comme des Sbires pour la Demoiselle."
+      },
+	  {
+        "id": "Golem",
+        "reason": "Si le Golem accuse une Émeute, ce joueur ne meurt pas."
+      },
+	  {
+        "id": "Hatter",
+        "reason": "Si à la mort du Chapelier, une Émeute choisit de devenir un autre Démon, les autres Émeutes doivent devenir des Sbires. Si à la mort du Chapelier, le Démon choisit de devenir Émeute, les Sbires deviennent des Émeutes aussi."
+      },
+      {
+        "id": "Devil's Advocate",
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour l'Avocat du Diable."
+      },
+      {
+        "id": "Pit-Hag",
+        "reason": "Si le Chaudronnier crée une Émeute, tous les joueurs mauvais deviennent des Émeutes. Si le Chaudronnier crée une Émeute après le jour 3, la partie continue pour un jour de plus."
       }
     ]
   }

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -9,15 +9,6 @@
     ]
   },
   {
-    "id": "Lycanthrope",
-    "hatred": [
-      {
-        "id": "Gambler",
-        "reason": "Si le Lycanthrope est en vie et que le Parieur se tue lui-même durant la nuit, aucun autre joueur ne peut mourir cette nuit."
-      }
-    ]
-  },
-  {
     "id": "Philosopher",
     "hatred": [
       {
@@ -33,11 +24,15 @@
         "id": "Juggler",
         "reason": "Si le Jongleur a deviné des rôles durant son premier jour et est alors mort par exécution, le Cannibale apprend cette nuit combien de rôles le Jongleur a deviné correctement."
       },
-	  {
+      {
+        "id": "Poppy Grower",
+        "reason": "Si le Cannibale mange le Planteur de pavot, puis meurt ou perd la capacité du Planteur de pavot, le Démon et les Sbires apprennent qui sont leurs alliés cette nuit."
+      },
+      {
         "id": "Butler",
         "reason": "Si le Cannibale gagne la capacité du Majordome, il l'apprend."
       },
-	  {
+      {
         "id": "Zealot",
         "reason": "Si le Cannibale gagne la capacité du Fanatique, il l'apprend."
       }

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -472,7 +472,7 @@
       },
       {
         "id": "Goon",
-        "reason": "Si le Kazali choisit de transformer l'Homme de main en Sbire, il devient ivre, et les Sbires restants sont choisis par le Narrateur sans prendre en compte les décisions du Kazali."
+        "reason": "Le Kazali peut choisir que l'Homme de main devient un de ses mauvais Sbires."
       },
       {
         "id": "Marionette",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -31,7 +31,7 @@
     "hatred": [
       {
         "id": "Juggler",
-        "reason": "Si le Jongleur a deviné des rôles durant son premier jour et est alors mort par exécution, le Cannibale apprend combien de rôles le Jongleur a deviné correctement."
+        "reason": "Si le Jongleur a deviné des rôles durant son premier jour et est alors mort par exécution, le Cannibale apprend cette nuit combien de rôles le Jongleur a deviné correctement."
       },
 	  {
         "id": "Butler",
@@ -126,7 +126,7 @@
     "hatred": [
       {
         "id": "Village Idiot",
-        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier peut en créer un nouveau. L'Idiot du Village ivre peut alors changer."
+        "reason": "S'il y a moins de trois Idiots du Village, le Chaudronnier peut en créer un nouveau. Il se peut alors que l'Idiot du Village ivre change."
       },
       {
         "id": "Cult Leader",
@@ -242,7 +242,7 @@
       },
       {
         "id": "Alchemist",
-        "reason": "Si un Alchimiste-Invocateur est en jeu, la partie commence avec un Démon, comme d'habitude. Si l'Alchimiste-Invocateur désigne un joueur, il le transforme en Démon mais ne change pas son alignement.""
+        "reason": "Si un Alchimiste-Invocateur est en jeu, la partie commence avec un Démon, comme d'habitude. Si l'Alchimiste-Invocateur désigne un joueur, il le transforme en Démon mais ne change pas son alignement."
       },
       {
         "id": "Poppy Grower",
@@ -270,7 +270,7 @@
       },
       {
         "id": "Zombuul",
-        "reason": "Si l'Invocateur change un joueur mort en Zombuul, le Narrateur traite ce joueur comme un Zombuul qui a été tué une fois."
+        "reason": "Si l'Invocateur change un joueur mort en Zombuul, le Narrateur traite ce joueur comme un Zombuul qui est mort une fois."
       },
 	  {
         "id": "Legion",
@@ -282,7 +282,7 @@
       },
       {
         "id": "Riot",
-        "reason": "Si l'Invocateur crée une Émeute, le joueur choisi et tous les mauvais deviennent des Émeutes. Le joueur choisi doit être un des bons voisins vivants de l'Invocateur."
+        "reason": "Si l'Invocateur crée une Émeute, tous les Sbires deviennent également des Émeutes."
       }
     ]
   },
@@ -301,6 +301,15 @@
       {
         "id": "Plague Doctor",
         "reason": "Si le Médecin de Peste est exécuté et que le Narrateur aurait du gagner une capacité d'Homme-bombe, la capacité d'Homme-bombe s'active immédiatement."
+      }
+    ]
+  },
+  {
+    "id": "Mastermind",
+    "hatred": [
+      {
+        "id": "Al-Hadikhia",
+        "reason": "Si l'Al-Hadikhia meurt par exécution, et si le Cerveau est en vie, l'Al-Hadikhia désigne trois joueurs bons cette nuit. Si tous choisit de vivre, les mauvais gagnent ; sinon, les bons gagnent."
       }
     ]
   },
@@ -350,7 +359,7 @@
       },
       {
         "id": "Fearmonger",
-        "reason": "Le Vizir se réveille avec le Semeur de peur, et ne peut pas exécuter ce joueur."
+        "reason": "Le Vizir se réveille avec le Semeur de peur, apprend quel joueur celui-ci choisit, et ne peut pas exécuter ce joueur."
       }
     ]
   },
@@ -435,7 +444,7 @@
       },
       {
         "id": "Hatter",
-        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi un rôle de Sbire et a la garde du Bébé monstre cette nuit."
+        "reason": "Si un Démon choisit de devenir Bébé monstre, il choisit aussi le Sbire qu'il devient et a la garde du Bébé monstre cette nuit."
       },
       {
         "id": "Scarlet Woman",
@@ -484,10 +493,6 @@
     "id": "Al-Hadikhia",
     "hatred": [
       {
-        "id": "Mastermind",
-        "reason": "Si l'Al-Hadikhia meurt par exécution, et si le Cerveau est en vie, l'Al-Hadikhia désigne trois joueurs bons cette nuit. Si tous choisit de vivre, les mauvais gagnent ; sinon, les bons gagnent."
-      },
-      {
         "id": "Scarlet Woman",
         "reason": "S'il y a deux Al-Hadikhias en vie, la Gourgandine devenue Al-Hadikhia redevient Gourgandine."
       }
@@ -507,7 +512,7 @@
     "hatred": [
       {
         "id": "Scarlet Woman",
-        "reason": "Si le Fang Gu désigne un Étranger et meurt, La Gourgandine ne devient pas Fang Gu ."
+        "reason": "Si le Fang Gu désigne un Étranger et meurt, La Gourgandine ne devient pas le Fang Gu."
       }
     ]
   },
@@ -631,7 +636,7 @@
       },
       {
         "id": "Undertaker",
-        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Fossoyeur"
+        "reason": "Les joueurs qui meurent par accusation apparaîssent comme exécutés pour le Fossoyeur."
       },
       {
         "id": "Innkeeper",

--- a/src/store/locale/fr/hatred.json
+++ b/src/store/locale/fr/hatred.json
@@ -358,14 +358,6 @@
     "id": "Organ Grinder",
     "hatred": [
       {
-        "id": "Preacher",
-        "reason": "Si le Prêcheur retire sa capacité à l'Organiste barbare, l'Organiste barbare garde sa capacité mais le Prêcheur garde les yeux ouverts durant les votes."
-      },
-	  {
-        "id": "Minstrel",
-        "reason": "Si le Ménestrel rend tout le monde ivre, l'Organiste barbare garde sa capacité mais le Ménestrel garde les yeux ouverts durant les votes."
-      },
-      {
         "id": "Butler",
         "reason": "Si les votes ont lieu à bulletin secret à cause de l'Organiste barbare, le Majordome peut lever sa main mais son vote ne compte que si son maître la lève aussi."
       }
@@ -472,7 +464,7 @@
       },
       {
         "id": "Soldier",
-        "reason": "Si le Kazali transforme le Soldat en Sbire, le Soldat choisit quel Sbire non-distribué il devient."
+        "reason": "Le Kazali peut choisir que le Soldat devient un de ses mauvais Sbires."
       },
       {
         "id": "Choirboy",


### PR DESCRIPTION
Grosse mise à jour sur les jinxes.
J'ai mis tous les jinxes actuel, avec tous les ajouts et toutes les modifications récentes.
J'en ai également profité pour remettre des jinxes dans l'ordre officiel (du style Invocateur/Kazali alors qu'on avait marqué Kazali/Invocateur).
J'en ai enfin profité pour remettre les persos dans l'ordre de script officiel*. Ainsi, sur la plupart des scripts, les jinxes seront affichés dans le même ordre que les rôles.


\* Ordre dans lequel les personnages doivent être affichés sur la liste des rôles. En gros : Villageois - Étrangers - Sbires - Démons, avec, dans chaque catégorie : rôles de première nuit - rôles de toutes les nuits - rôles qui n'agissent jamais la nuit. En gros. J'ai l'ordre précis noté quelque part.


PS : Si tu ne merges pas tout les pull requests en même temps, ça m'arrangerait que tu acceptes cette pull request (et celle de l'ordre nocturne) en dernier. Comme ça, s'il y a des changements de jinxes entretemps, je pourrai mettre à jour la pull request avant qu'elle ne soit mergée.