### PR TITLE
Showing pertinent Fabled during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Showing pertinent Fabled during setup
 
 ### Version 3.20.0
 

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -34,7 +34,17 @@
         </div>
       </li>
     </ul>
-    <div class="warning" v-if="hasSelectedSetupRoles">
+	<ul class="tokens">
+      <li
+        v-for="role in fabledWithSetup"
+        :class="['fabled', 'selected']"
+        :key="role.id"
+      >
+        <Token :role="role" />
+        <font-awesome-icon icon="exclamation-triangle" />
+      </li>
+	</ul>
+    <div class="warning" v-if="hasSelectedSetupRoles || fabledWithSetup.length">
       <font-awesome-icon icon="exclamation-triangle" />
       <span>{{ locale.modal.roles.warning }}</span>
     </div>
@@ -97,8 +107,18 @@ export default {
         roles.some((role) => role.selected && role.setup),
       );
     },
+	fabledWithSetup: function() {
+	  const { fabled } = this.$store.state.players;
+	  let res = [];
+	  for(let i=0 ; i<fabled.length ; i++) {
+	    if(fabled[i].setup) {
+		  res.push(fabled[i]) ;
+		}
+	  }
+	  return res ;
+	},
     ...mapState(["roles", "modals", "locale"]),
-    ...mapState("players", ["players"]),
+    ...mapState("players", ["players", "fabled"]),
     ...mapGetters({ nonTravelers: "players/nonTravelers" }),
   },
   methods: {
@@ -165,7 +185,7 @@ export default {
     roles() {
       this.selectRandomRoles();
     },
-  },
+  }
 };
 </script>
 
@@ -213,6 +233,11 @@ ul.tokens {
       box-shadow:
         0 0 10px $traveler,
         0 0 10px $traveler;
+    }
+    &.fabled {
+      box-shadow:
+        0 0 10px $fabled,
+        0 0 10px $fabled;
     }
     &:hover {
       transform: scale(1.2);

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -34,7 +34,7 @@
         </div>
       </li>
     </ul>
-	<ul class="tokens">
+    <ul class="tokens">
       <li
         v-for="role in fabledWithSetup"
         :class="['fabled', 'selected']"
@@ -43,7 +43,7 @@
         <Token :role="role" />
         <font-awesome-icon icon="exclamation-triangle" />
       </li>
-	</ul>
+    </ul>
     <div class="warning" v-if="hasSelectedSetupRoles || fabledWithSetup.length">
       <font-awesome-icon icon="exclamation-triangle" />
       <span>{{ locale.modal.roles.warning }}</span>
@@ -107,16 +107,16 @@ export default {
         roles.some((role) => role.selected && role.setup),
       );
     },
-	fabledWithSetup: function() {
-	  const { fabled } = this.$store.state.players;
-	  let res = [];
-	  for(let i=0 ; i<fabled.length ; i++) {
-	    if(fabled[i].setup) {
-		  res.push(fabled[i]) ;
-		}
-	  }
-	  return res ;
-	},
+    fabledWithSetup: function() {
+      const { fabled } = this.$store.state.players;
+      let res = [];
+      for(let i=0 ; i<fabled.length ; i++) {
+        if(fabled[i].setup) {
+          res.push(fabled[i]) ;
+        }
+      }
+      return res ;
+    },
     ...mapState(["roles", "modals", "locale"]),
     ...mapState("players", ["players", "fabled"]),
     ...mapGetters({ nonTravelers: "players/nonTravelers" }),
@@ -185,7 +185,7 @@ export default {
     roles() {
       this.selectRandomRoles();
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -107,15 +107,15 @@ export default {
         roles.some((role) => role.selected && role.setup),
       );
     },
-    fabledWithSetup: function() {
+    fabledWithSetup: function () {
       const { fabled } = this.$store.state.players;
       let res = [];
-      for(let i=0 ; i<fabled.length ; i++) {
-        if(fabled[i].setup) {
-          res.push(fabled[i]) ;
+      for (let i = 0 ; i < fabled.length ; i++) {
+        if (fabled[i].setup) {
+          res.push(fabled[i]);
         }
       }
-      return res ;
+      return res;
     },
     ...mapState(["roles", "modals", "locale"]),
     ...mapState("players", ["players", "fabled"]),

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -110,7 +110,7 @@ export default {
     fabledWithSetup: function () {
       const { fabled } = this.$store.state.players;
       let res = [];
-      for (let i = 0 ; i < fabled.length ; i++) {
+      for (let i = 0; i < fabled.length; i++) {
         if (fabled[i].setup) {
           res.push(fabled[i]);
         }


### PR DESCRIPTION
Lors du choix des rôles, les Fabuleux ayant un impact sur la distribution sont à présent affichés, comme pense-bête.

Pour l'instant, cela ne concerne que la Sentinelle, mais le code est général, et si d'autres Fabuleux sont créés plus tard, ils seront pris en compte.