### PR TITLE
Unique night order bubbles for multiple role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Unique night order bubble for each player with the same role
 
 ### Version 3.20.0
 

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -29,27 +29,29 @@ const getters = {
     const firstNight = [0];
     const otherNight = [0];
     fabled.forEach((role) => {
-      if (role.firstNight && !firstNight.includes(role)) {
+      if (role.firstNight) {
         firstNight.push(role);
       }
-      if (role.otherNight && !otherNight.includes(role)) {
+      if (role.otherNight) {
         otherNight.push(role);
       }
     });
-    players.forEach(({ role }) => {
-      if (role.firstNight && !firstNight.includes(role)) {
-        firstNight.push(role);
+    players.forEach((player) => {
+      if (player.role.firstNight) {
+        firstNight.push(player);
       }
-      if (role.otherNight && !otherNight.includes(role)) {
-        otherNight.push(role);
+      if (player.role.otherNight) {
+        otherNight.push(player);
       }
     });
-    firstNight.sort((a, b) => a.firstNight - b.firstNight);
-    otherNight.sort((a, b) => a.otherNight - b.otherNight);
+	// If x has an attribute 'role' (meaning x is a player), then, to know their night order, we look at x.role.firstNight or x.role.otherNight
+	// Else, (meaning x is instead a Fabled), to know their night order we look at x.firstNight or x.otherNight
+    firstNight.sort((a, b) => (a.role ? a.role.firstNight : a.firstNight) - (b.role ? b.role.firstNight : b.firstNight));
+    otherNight.sort((a, b) => (a.role ? a.role.otherNight : a.otherNight) - (b.role ? b.role.otherNight : b.otherNight));
     const nightOrder = new Map();
     players.forEach((player) => {
-      const first = Math.max(firstNight.indexOf(player.role), 0);
-      const other = Math.max(otherNight.indexOf(player.role), 0);
+      const first = Math.max(firstNight.indexOf(player), 0);
+      const other = Math.max(otherNight.indexOf(player), 0);
       nightOrder.set(player, { first, other });
     });
     fabled.forEach((role) => {

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -46,8 +46,16 @@ const getters = {
     });
     // If x has an attribute 'role' (meaning x is a player), then, to know their night order, we look at x.role.firstNight or x.role.otherNight
     // Else, (meaning x is instead a Fabled), to know their night order we look at x.firstNight or x.otherNight
-    firstNight.sort((a, b) => (a.role ? a.role.firstNight : a.firstNight) - (b.role ? b.role.firstNight : b.firstNight));
-    otherNight.sort((a, b) => (a.role ? a.role.otherNight : a.otherNight) - (b.role ? b.role.otherNight : b.otherNight));
+    firstNight.sort(
+      (a, b) =>
+        (a.role ? a.role.firstNight : a.firstNight) -
+        (b.role ? b.role.firstNight : b.firstNight),
+    );
+    otherNight.sort(
+      (a, b) =>
+        (a.role ? a.role.otherNight : a.otherNight) -
+        (b.role ? b.role.otherNight : b.otherNight),
+    );
     const nightOrder = new Map();
     players.forEach((player) => {
       const first = Math.max(firstNight.indexOf(player), 0);

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -44,8 +44,8 @@ const getters = {
         otherNight.push(player);
       }
     });
-	// If x has an attribute 'role' (meaning x is a player), then, to know their night order, we look at x.role.firstNight or x.role.otherNight
-	// Else, (meaning x is instead a Fabled), to know their night order we look at x.firstNight or x.otherNight
+    // If x has an attribute 'role' (meaning x is a player), then, to know their night order, we look at x.role.firstNight or x.role.otherNight
+    // Else, (meaning x is instead a Fabled), to know their night order we look at x.firstNight or x.otherNight
     firstNight.sort((a, b) => (a.role ? a.role.firstNight : a.firstNight) - (b.role ? b.role.firstNight : b.firstNight));
     otherNight.sort((a, b) => (a.role ? a.role.otherNight : a.otherNight) - (b.role ? b.role.otherNight : b.otherNight));
     const nightOrder = new Map();


### PR DESCRIPTION
Ce request a pour but, quand plusieurs joueurs ont le même rôle, de donner à chacun son propre ordre nocturne sur les bulles rouges et bleues. (Par exemple, trois Idiots du Village pourront être numérotés 4, 5 et 6 au lieu de 4, 4 et 4 à l'heure actuelle).

Cela peut fortement aider le Narrateur, s'il se fie à ces bulles. Par exemple, il pourra ainsi réveiller tous les Idiots du Village, l'un après l'autre, sans risque d'en oublier un. Ou encore, il pourra ainsi se souvenir que chaque Légion en vie peut tuer un joueur.