### PR TITLE
New token for the Lunatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Adding tokens to some characters
 
 ### Version 3.22.0
 

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -636,7 +636,8 @@
     "otherNightReminder": "Allow the Lunatic to do the actions of the Demon. Place their 'attack' markers. If the Lunatic selected players: Wake the Demon. Show the 'attack' marker, then point to each marked player. Remove any Lunatic 'attack' markers.",
     "reminders": [],
     "remindersGlobal": [
-      "Lunatic"
+      "Lunatic",
+      "Chosen"
     ],
     "setup": false,
     "ability": "You think you are a Demon, but you are not. The Demon knows who you are & who you choose at night."

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -637,7 +637,8 @@
     "otherNightReminder": "Permettez à l'Aliéné de réaliser les actions du Démon qu'il croit être. Placez le(s) marqueur(s) d'attaque. Si l'Aliéné a indiqué des joueurs, réveillez le Démon. Dévoilez au Démon les marqueurs de l'Aliéné puis retirez-les.",
     "reminders": [],
     "remindersGlobal": [
-      "Aliéné"
+      "Aliéné",
+      "Désigné"
     ],
     "setup": true,
     "ability": "Vous croyez être un Démon, mais vous ne l'êtes pas. Le Démon sait qui vous êtes et qui vous désignez chaque nuit."


### PR DESCRIPTION
Sert à indiquer quels joueurs est-ce que l'Aliéné désigne.

Peut-être utile pour s'en souvenir quand on doit voir le Démon (surtout si l'Aliéné pense être un Démon qui désigne plusieurs personnes). Peut aussi être utile pour l'Espion.