### PR TITLE
Updating the icon for "Demon info & bluffs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Updating the icon for "Demon info & bluffs"
 
 ### Version 3.22.0
 

--- a/src/components/modals/NightOrderModal.vue
+++ b/src/components/modals/NightOrderModal.vue
@@ -201,7 +201,7 @@ export default {
               this.locale.modal.nightOrder.minionInfoDescription,
           },
           {
-            id: "evil",
+            id: "demon",
             name: this.locale.modal.nightOrder.demonInfo,
             firstNight: 18,
             team: "demon",


### PR DESCRIPTION
J'avais oublié, mais quand j'ai modifié les images pour "Townsfolk", "Outsider", "Minion" et "Demon", j'aurais dû modifier ça aussi. On s'en est rendu compte lors de la dernière partie.