### PR TITLE
Uniformizing the translation of "choose a player"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Minor corrections in the French version (mainly in Trouble Brewing)
 
 ### Version 3.22.0
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -116,7 +116,7 @@
       "Protégé"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, choisissez un joueur (autre que vous-même) : il est à l'abri du Démon cette nuit."
+    "ability": "Chaque nuit*, désignez un joueur (autre que vous-même) : il est à l'abri du Démon cette nuit."
   },
   {
     "id": "ravenkeeper",
@@ -762,7 +762,7 @@
       "3 Attaques"
     ],
     "setup": false,
-    "ability": "Chaque nuit*, vous pouvez désigner un joueur : il meurt. Si votre dernier choix ne portait sur personne, choisissez 3 joueurs cette nuit."
+    "ability": "Chaque nuit*, vous pouvez désigner un joueur : il meurt. Si votre dernier choix ne portait sur personne, désignez 3 joueurs cette nuit."
   },
   {
     "id": "apprentice",


### PR DESCRIPTION
Histoire que "choose a player" soit toujours traduit de la même manière.