### PR TITLE
Updating the Virgin's French description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Minor corrections in the French version (mainly in Trouble Brewing)
 
 ### Version 3.22.0
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -144,7 +144,7 @@
       "Épuisé"
     ],
     "setup": false,
-    "ability": "La première fois que vous êtes accusé, si la personne qui vous accuse est un Villageois, elle est exécutée immédiatement."
+    "ability": "La première fois que vous êtes accusé, si l'accusateur est un Villageois, il est exécuté immédiatement."
   },
   {
     "id": "slayer",


### PR DESCRIPTION
Plus proche de l'original. De plus, les descriptions n'utilisent pas des termes aussi vagues que "personne".