### PR TITLE
Updating Gunslinger's French description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Minor corrections in the French version (mainly in Trouble Brewing)
 
 ### Version 3.22.0
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -357,7 +357,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Chaque jour, après que les votes de la première accusation aient été comptabilisés. Vous pouvez désigner l'un des joueurs qui a voté : il meurt."
+    "ability": "Chaque jour, après que les votes de la première accusation aient été comptés, vous pouvez désigner l'un des joueurs qui a voté : il meurt."
   },
   {
     "id": "scapegoat",


### PR DESCRIPTION
D'une part, parce que ça n'a aucun sens de diviser ça en deux phrases. D'autre part, pour la raccourcir un peu et la rendre aussi courte que les descriptions habituelles.