### PR TITLE
Adding a system of roles in multiple copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Adding a system of roles in multiple copies
 
 ### Version 3.23.0
 

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -24,7 +24,7 @@
       >
         <Token :role="role" />
         <font-awesome-icon icon="exclamation-triangle" v-if="role.setup" />
-        <div class="buttons" v-if="allowMultiple">
+        <div class="buttons" v-if="allowMultiple || role.multiple">
           <font-awesome-icon
             icon="minus-circle"
             @click.stop="role.selected--"

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -1643,6 +1643,7 @@
       "Drunk"
     ],
     "setup": true,
+    "multiple": true,
     "ability": "Each night, choose a player: you learn their alignment. [+0 to +2 Village Idiots. 1 of the extras is drunk]"
   },
   {
@@ -2114,6 +2115,7 @@
       "About to die"
     ],
     "setup": true,
+    "multiple": true,
     "ability": "Each night*, a player might die. Executions fail if only evil voted. You register as a Minion too. [Most players are Legion]"
   },
   {

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1648,7 +1648,8 @@
       "Ivre"
     ],
     "setup": true,
-    "ability": "Chaque nuit, désignez un joueur : vous apprenez son alignement. [+0 à +2 Idiots du village, l’un d’eux étant ivre]"
+    "multiple": true,
+    "ability": "Chaque nuit, désignez un joueur : vous apprenez son alignement. [+0 à +2 Idiots du Village, l’un d’eux étant ivre]"
   },
   {
     "id": "knight",
@@ -2119,6 +2120,7 @@
       "Condamné"
     ],
     "setup": true,
+    "multiple": true,
     "ability": "Chaque nuit*, il se peut qu'un joueur meure. Les exécutions ratent sans vote de bon. Vous apparaissez aussi comme Sbire. [Majorité de Légion]"
   },
   {


### PR DESCRIPTION
Système de rôles multiple.
Si un rôle peut commencer la partie en plusieurs exemplaires, le Narrateur peut à présent en rajouter plusieurs, sans avoir besoin de cocher l'option "Permettre les doublons de personnages".
Je pense néanmoins que c'est mieux de laisser cette option en plus, pour permettre une possibilité de mettre d'autres personnages en double, en cas d'Amnésique ou d'Athée par exemple.

PS : J'en ai profité pour corriger une petite erreur dans la VF de l'Idiot du Village. Trois fois rien, une histoire de majuscule.