### PR TITLE
Correcting a colour bug with the icon for number of Townsfolk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adding a system of roles in multiple copies
 - Adding the Banshee
+- Correcting a colour bug with the icon for number of Townsfolk
 
 ### Version 3.23.2
 

--- a/src/components/TownInfo.vue
+++ b/src/components/TownInfo.vue
@@ -30,7 +30,7 @@
     <li v-if="players.length - teams.traveler >= 5">
       <span>
         {{ teams.townsfolk }}
-        <font-awesome-icon icon="user-friends" class="townfolk fa-user-friends" />
+        <font-awesome-icon icon="user-friends" class="townsfolk fa-user-friends" />
       </span>
       <span>
         {{ teams.outsider }}


### PR DESCRIPTION
Petite correction de bug : l'icône pour le nombre de Villageois s'affiche actuellement en blanc au lieu de s'afficher en bleu.

Pour le coup, rien de bien compliquer à régler, il y avait juste une faute de frappe dans le nom d'une classe.