### PR TITLE
Updating Reptiles II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adding a system of roles in multiple copies
 - Adding the Banshee
+- Updating some scripts
 
 ### Version 3.23.2
 

--- a/src/assets/scripts/reptiles2.json
+++ b/src/assets/scripts/reptiles2.json
@@ -1,6 +1,7 @@
 [
     {
         "id": "_meta",
+        "logo": "reptiles",
         "name": "Reptiles II : Lizard in the city",
         "author": "Aero"
     },
@@ -81,8 +82,5 @@
     },
     {
         "id": "storm_catcher"
-    },
-    {
-        "id": "djinn"
     }
 ]


### PR DESCRIPTION
Suppression du Djinn, qui n'a rien à faire sur ce script.
Il avait été mis pour une règle spéciale (qui n'apporte pas grand-chose), et le Djinn ne sert pas à ça. Je compte faire à un moment une mise à jour de tous ceux qui utilisent une règle spéciale pour que cette règle soit affichée.