### PR TITLE
Updating Uncertain death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adding a system of roles in multiple copies
 - Adding the Banshee
+- Updating some scripts
 
 ### Version 3.23.2
 

--- a/src/assets/scripts/uncertain_death.json
+++ b/src/assets/scripts/uncertain_death.json
@@ -3,7 +3,7 @@
     "id": "_meta",
     "name": "Uncertain Death",
     "author": "Matt",
-    "logo": "https://cdn.shopify.com/oxygen/57467011226/524442/h11pcta59/build/_assets/Pukka_Website-23QXSH5C.png"
+    "logo": "pukka"
   },
   {
     "id": "clockmaker"
@@ -27,13 +27,13 @@
     "id": "flowergirl"
   },
   {
-    "id": "monk"
-  },
-  {
     "id": "oracle"
   },
   {
     "id": "undertaker"
+  },
+  {
+    "id": "monk"
   },
   {
     "id": "artist"


### PR DESCRIPTION
Simplement une question d'ordre dans lequel les personnages doivent être à présent affichés.