### PR TITLE
Shorting a little the French Mayor's description (V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Minor ability rephrasing in the French version (mainly in Sects & Violets)
 
 ### Version 3.24.1
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -185,7 +185,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Si 3 joueurs sont en vie & qu'il n'y a pas d'exécution, votre équipe gagne. Si vous mourez la nuit, il se peut qu'un autre joueur meure à la place."
+    "ability": "S'il y a 3 joueurs en vie & s'il n'y a pas d'exécution, votre équipe gagne. Si vous mourez la nuit, il se peut qu'un autre joueur meure à la place."
   },
   {
     "id": "butler",


### PR DESCRIPTION
Contrairement au changement de traduction précédent, je pense que celui-ci ne devrait pas poser problème.
Et (avec les espaces qui, sur le site, prennent moins de place que les autres caractères), la description est maintenant plus courte.