### PR TITLE
French Barber's description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming version
 
-
+- Minor ability rephrasing in the French version (mainly in Sects & Violets)
 
 ### Version 3.24.1
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1069,7 +1069,7 @@
       "Échanges"
     ],
     "setup": false,
-    "ability": "Si vous êtes mort aujourd'hui (de jour comme de nuit), le Démon peut désigner 2 joueurs qui ne sont pas un autre Démon et échanger leurs personnages."
+    "ability": "Si vous êtes mort aujourd'hui (de jour ou de nuit), le Démon peut désigner 2 joueurs (pas un autre Démon) et échanger leur personnage."
   },
   {
     "id": "klutz",


### PR DESCRIPTION
D'une part, la description du Barbier est maintenant plus courte.
D'autre part, chaque joueur n'ayant qu'un seul personnage, même s'ils sont plusieurs, il faut utiliser "leur personnage" sans S (je sais, moi aussi, je trouve que ça fait bizarre, mais c'est comme ça).