### PR TITLE
If Voudon is in play, allowing dead players to vote without vote token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replacing the icon custom.png
 - Changing the order of the three editions, to match the official order
 - Minor ability rephrasing in the French version (mainly in Sects & Violets)
+- If Voudon is in play, allowing dead players to vote without vote token.
 
 ### Version 3.24.4
 - Bugfix missing images

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -182,12 +182,20 @@ export default {
       );
       return index >= 0 ? !!this.session.votes[index] : undefined;
     },
+    noVoudon: function() {
+      for (let i=0 ; i<this.players.length ; i++) {
+        if(this.players[i].role.id == "voudon")
+          return this.players[i].isDead ;
+      }
+      return true ;
+    },
     canVote: function () {
       if (!this.player) return false;
       if (
         this.player.isVoteless &&
-        ((this.nominee && this.nominee.role.team !== "traveler") ||
-          typeof this.session.nomination[1] === "string")
+        (this.nominee && this.nominee.role.team !== "traveler" ||
+          typeof this.session.nomination[1] === "string") &&
+		this.noVoudon
       )
         return false;
       const session = this.session;

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -195,7 +195,7 @@ export default {
         this.player.isVoteless &&
         (this.nominee && this.nominee.role.team !== "traveler" ||
           typeof this.session.nomination[1] === "string") &&
-		this.noVoudon
+        this.noVoudon
       )
         return false;
       const session = this.session;


### PR DESCRIPTION
Probablement inutile si le Vaudou est présent dès le début de la partie. En revanche, s'il arrive en cours de route, ça peut se révéler nécessaire.