### PR TITLE
Fixing a bug with the print of the jinxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replacing the icon custom.png
 - Changing the order of the three editions, to match the official order
 - Minor ability rephrasing in the French version (mainly in Sects & Violets)
+- Fixing a bug with the print of the jinxes
 
 ### Version 3.24.4
 - Bugfix missing images

--- a/src/components/modals/ReferenceModal.vue
+++ b/src/components/modals/ReferenceModal.vue
@@ -39,10 +39,10 @@
       <ul>
         <li v-for="(jinx, index) in jinxed" :key="index">
           <span class="icon" :style="{
-            backgroundImage: rolePath(jinx.first),
+            backgroundImage: 'url(' + rolePath(jinx.first) + ')',
           }"></span>
           <span class="icon" :style="{
-            backgroundImage: rolePath(jinx.second),
+            backgroundImage: 'url(' + rolePath(jinx.second) + ')',
           }"></span>
           <div class="role">
             <span class="name">{{ jinx.first.name }} & {{ jinx.second.name }}</span>


### PR DESCRIPTION
Correction d'un bug qui avait lieu quand on affichait la liste des rôles.
S'il y a des jinxes, la version précédente n'affichait pas les icônes concernées.