### PR TITLE
Allowing the Story Teller to give back vote tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Allowing the Story Teller to give back vote token
 
 ### Version 4.0.1
 

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -4,7 +4,7 @@
       {
         dead: props.player.isDead,
         marked: session.markedPlayer === index,
-        'no-vote': props.player.isVoteless,
+        'no-vote': !props.player.voteToken,
         you: session.sessionId && props.player.id && props.player.id === session.playerId,
         'vote-yes': session.votes[index],
         'vote-lock': voteLocked,
@@ -76,7 +76,10 @@
 
       <!-- Ghost vote icon -->
       <font-awesome-icon icon="vote-yea" class="fa fa-vote-yea has-vote"
-        v-if="props.player.isDead && !props.player.isVoteless" @click="updatePlayer('isVoteless', true)"
+        v-if="(props.player.isDead || player.role.id=='beggar') && props.player.voteToken" @click="updatePlayer('voteToken', false)"
+        :title="locale.player.ghostVote" />
+      <font-awesome-icon icon="vote-yea" class="fa fa-vote-yea has-vote no-token"
+        v-if="(props.player.isDead || player.role.id=='beggar') && !props.player.voteToken && !session.isSpectator" @click="updatePlayer('voteToken', true)"
         :title="locale.player.ghostVote" />
 
       <!-- On block icon -->
@@ -233,19 +236,19 @@ function toggleStatus() {
       if (props.player.isMarked) {
         updatePlayer("isMarked", false);
       }
-    } else if (props.player.isVoteless) {
-      updatePlayer("isVoteless", false);
+    } else if (!props.player.voteToken) {
+      updatePlayer("voteToken", true);
       updatePlayer("isDead", false);
     } else {
-      updatePlayer("isVoteless", true);
+      updatePlayer("voteToken", false);
     }
   } else {
     updatePlayer("isDead", !props.player.isDead);
     if (props.player.isMarked) {
       updatePlayer("isMarked", false);
     }
-    if (props.player.isVoteless) {
-      updatePlayer("isVoteless", false);
+    if (props.player.voteToken != props.player.isDead) {
+      updatePlayer("voteToken", !props.player.voteToken);
     }
   }
 }
@@ -592,6 +595,18 @@ li.move:not(.from) .player .overlay svg.move {
 .player .has-vote {
   color: #fff;
   filter: drop-shadow(0 0 3px black);
+  transition: opacity 250ms;
+  z-index: 2;
+
+  #townsquare.public & {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.player .no-token {
+  color: #000;
+  filter: drop-shadow(0 0 3px white);
   transition: opacity 250ms;
   z-index: 2;
 

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -203,7 +203,8 @@ const noVoudon = computed(() => {
 const canVote = computed(() => {
   if (!player.value) return false;
   if (
-    player.value.isVoteless &&
+    (player.value.isDead || player.value.role.id == "beggar") &&
+    !player.value.voteToken &&
     (nominee.value && nominee.value.role.team !== "traveler" ||
       typeof session.value.nomination[1] === "string") &&
     noVoudon.value

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -3,7 +3,7 @@ const NEWPLAYER = {
   id: "",
   role: {},
   reminders: [],
-  isVoteless: false,
+  voteToken: false,
   isDead: false,
   pronouns: "",
 };

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -269,7 +269,7 @@ class LiveSession {
       name: player.name,
       id: player.id,
       isDead: player.isDead,
-      isVoteless: player.isVoteless,
+      voteToken: player.voteToken,
       pronouns: player.pronouns,
       ...(player.role && player.role.team === "traveler"
         ? { roleId: player.role.id }
@@ -341,7 +341,7 @@ class LiveSession {
       const player = players[x];
       const { roleId } = state;
       // update relevant properties
-      ["name", "id", "isDead", "isVoteless", "pronouns"].forEach((property) => {
+      ["name", "id", "isDead", "voteToken", "pronouns"].forEach((property) => {
         const value = state[property];
         if (player[property] !== value) {
           this._store.commit("players/update", { player, property, value });


### PR DESCRIPTION
Le Narrateur peut à présent redonner son jeton de vote à un mort, sans avoir besoin de le ressusciter et re-tuer. Ce qui peut être utile par exemple en cas d'erreur ou de Passeur.
Après avoir retiré son jeton de vote à un joueur, celui-ci est remplacé par un jeton similaire mais noir (et visible par le Narrateur uniquement). Il suffit de cliquer à nouveau sur ce symbole pour redonner un jeton de vote.

J'en ai profité pour ajouter deux modifs qui y sont liées : 

- Il est à présent possible pour le Narrateur de donner un jeton de vote au Mendiant (exactement de la même manière), et le Mendiant ne peut pas voter s'il n'a pas ce jeton.
- Le terme "isVoteLess" peut prêter à confusion à présent, à cause des morts qui peuvent regagner leur jeton perdu, ou du Mendiant. Il est donc remplacé par voteToken (booléen qui est vrai si le joueur a un jeton de vote), nom que je trouve plus explicite.