### PR TITLE
Correcting Gossip's french reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Minor rephrasing in the French version (mainly in Sects & Violets and Bad Moon Rising)
 
 ### Version 4.0.1
 

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -482,7 +482,7 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 51,
-    "otherNightReminder": "Si les annonces publiques de la Commère étaient vraie aujourd'hui, choisisser un joueur non protégé. Ce joueur meurt.",
+    "otherNightReminder": "Si l'annonce publique de la Commère était vraie aujourd'hui, choisisser un joueur. Ce joueur meurt.",
     "reminders": [
       "Mort"
     ],


### PR DESCRIPTION
D'une part parce que la Commère ne fait qu'une seule annonce, d'autre part parce que, techniquement, rien n'empêche le Narrateur de choisir un joueur protégé.