### PR TITLE
Correcting Judge's French description

### DIFF
--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -807,7 +807,7 @@
       "Épuisé"
     ],
     "setup": false,
-    "ability": "Une fois par partie, si un autre joueur a lancé une accusation, vous pouvez forcer le résultat du vote à réussir ou à échouer."
+    "ability": "Une fois par partie, si un autre joueur a accusé, vous pouvez forcer l'exécution à réussir ou à échouer."
   },
   {
     "id": "bishop",


### PR DESCRIPTION
Ça n'a aucun sens de dire qu'un résultat "réussit ou échoue".