### PR TITLE
Shortening Voudon's French description

### DIFF
--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -836,7 +836,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Seuls vous et les morts pouvez voter. Les morts n'ont pas besoin de jetons pour voter. La majorité à 50% n'est pas requise pour condamner un joueur."
+    "ability": "Seuls vous et les morts pouvez voter. Les morts n'ont pas besoin de jeton pour voter. La majorité à 50% n'est pas requise."
   },
   {
     "id": "clockmaker",


### PR DESCRIPTION
(Au passage, la VO a également fait le choix de ne pas préciser "pour condamner")