### PR TITLE
Uniformizing the French translation of "an alive player"

### DIFF
--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -609,7 +609,7 @@
       "Mort"
     ],
     "setup": false,
-    "ability": "Quand vous apprenez votre mort, désignez publiquement un joueur encore en vie. Cette nuit, s'il était bon, il meurt."
+    "ability": "Quand vous apprenez votre mort, désignez publiquement un joueur vivant. Cette nuit, s'il était bon, il meurt."
   },
   {
     "id": "goon",
@@ -1082,7 +1082,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Quand vous apprenez votre mort, désignez publiquement un joueur encore en vie : s'il est Mauvais, votre équipe perd."
+    "ability": "Quand vous apprenez votre mort, désignez publiquement un joueur vivant. S'il est mauvais, votre équipe perd."
   },
   {
     "id": "eviltwin",


### PR DESCRIPTION
Histoire que ce soit toujours traduit de la même manière.
J'en ai profité pour modifier la ponctuation de l'Empoté, pour avoir la même qu'avec l'Enfant de la lune.