### PR TITLE
Correcting a bug with the number of votes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcomming Version
 
+- Correcting a bug with the "give back token" update
 - Allow voting delay to go down to 0 to lock everyone at once
 
 ### Version 4.1.0

--- a/src/components/TownInfo.vue
+++ b/src/components/TownInfo.vue
@@ -113,8 +113,8 @@ const teams = computed(() => {
     traveler: players.value.length - nonTravelers,
     alive,
     aliveNT,
-    votes: alive + players.value.filter(
-      player => player.isDead === true && player.isVoteless !== true
+    votes: players.value.filter(
+      player => (!player.isDead && player.role.id !== "beggar") || player.voteToken
     ).length,
   };
 });


### PR DESCRIPTION
Depuis la mise à jour des jetons de vote, et à cause d'un fichier que j'avais oublié de modifier, le nombre de personnes pouvant voter, au centre de la page, n'affichait plus la bonne valeur (il affichait toujours le nombre total de joueurs, morts ou vivants, avec ou sans jeton).

C'est à présent corrigé.