### PR TITLE
Ignoring out of date characters in the script builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Ignoring out of date characters in the script builder
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/components/modals/EditionModal.vue
+++ b/src/components/modals/EditionModal.vue
@@ -138,7 +138,7 @@ function toggleRole(id) {
 }
 
 function rolesForTeam(team) {
-  return draftPool.value?.filter((role) => role.team === team) ?? [];
+  return draftPool.value?.filter((role) => role.team === team && !role.outOfDate) ?? [];
 }
 
 function selectedInTeam(team) {

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -1913,6 +1913,7 @@
   },
   {
     "id": "mephit",
+    "outOfDate": true,
     "name": "Mezepheles",
     "edition": "",
     "team": "minion",

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1918,6 +1918,7 @@
   },
   {
     "id": "mephit",
+    "outOfDate": true,
     "name": "Mezepheles",
     "edition": "",
     "team": "minion",


### PR DESCRIPTION
Pour l'instant, ce changement ne concerne que le Méphite/Mezepheles, qui ne sera dorénavant affiché plus qu'une seule fois.

(Mais comme d'habitude, j'ai fait en sorte d’avoir un code général.)