### PR TITLE
When sending roles, checking if all roles can be sent to a player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- When sending roles, checking if all roles can be send to a player
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-- When sending roles, checking if all roles can be send to a player
+- When sending roles, checking if all roles can be sent to a player
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -263,10 +263,24 @@ const distributeRoles = () => {
   if (session.value.isSpectator) return;
   const popup = locale.value.prompt.sendRoles;
   if (confirm(popup)) {
-    store.commit('session/distributeRoles', true);
-    setTimeout(() => {
-      store.commit('session/distributeRoles', false);
-    }, 2000);
+    // Checking all players to see if one of them has a forbidden role
+    let forbiddenRole="";
+    for (let i=0 ; i<players.value.length && !forbiddenRole ; i++) {
+      if(players.value[i].role.forbidden) {
+        forbiddenRole = players.value[i].role.name;
+      }
+    }		
+    let confirmedDistribution = (forbiddenRole == "") ;		
+    if(!confirmedDistribution) {
+      const forbiddenPopup = locale.value.prompt.sendRolesWithForbidden1 + forbiddenRole + locale.value.prompt.sendRolesWithForbidden2;
+      confirmedDistribution = confirm(forbiddenPopup);
+    }
+    if(confirmedDistribution) {
+      store.commit('session/distributeRoles', true);
+      setTimeout(() => {
+        store.commit('session/distributeRoles', false);
+      }, 2000);
+    }
   }
 };
 

--- a/src/store/locale/en/roles.json
+++ b/src/store/locale/en/roles.json
@@ -216,6 +216,7 @@
       "Drunk"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "You do not know you are the Drunk. You think you are a Townsfolk character, but you are not."
   },
   {
@@ -640,6 +641,7 @@
       "Chosen"
     ],
     "setup": false,
+    "forbidden": true,
     "ability": "You think you are a Demon, but you are not. The Demon knows who you are & who you choose at night."
   },
   {
@@ -1957,6 +1959,7 @@
       "Is the Marionette"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "You think you are a good character but you are not. The Demon knows who you are. [You neighbour the Demon]"
   },
   {
@@ -2096,6 +2099,7 @@
       "Dead"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "Each night, Minions choose who babysits Lil' Monsta & 'is the Demon'. Each night*, a player might die. [+1 Minion]"
   },
   {

--- a/src/store/locale/en/ui.json
+++ b/src/store/locale/en/ui.json
@@ -58,6 +58,8 @@
     "background": "Enter custom background URL",
     "createSession": "Enter a channel number / name for your session",
     "sendRoles": "Do you want to distribute assigned characters to all SEATED players?",
+    "sendRolesWithForbidden1": "WARNING\nOne of the roles you want to distribute is a forbidden role (",
+    "sendRolesWithForbidden2": ").\nConfirm the distribution?",
     "imageOptIn": "Are you sure you want to allow custom images? A malicious script file author might track your IP address this way.",
     "joinSession": "Enter the channel number / name of the session you want to join",
     "leaveSession": "Are you sure you want to leave the active live game?",

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -216,6 +216,7 @@
       "Ivrogne"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "Vous ne savez pas que vous êtes l'Ivrogne. Vous croyez être un personnage Villageois, mais vous ne l'êtes pas."
   },
   {
@@ -641,6 +642,7 @@
       "Désigné"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "Vous croyez être un Démon, mais vous ne l'êtes pas. Le Démon sait qui vous êtes et qui vous désignez chaque nuit."
   },
   {
@@ -1962,6 +1964,7 @@
       "Marionnette"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "Vous croyez être un personnage bon, mais vous ne l'êtes pas. Le Démon sait qui vous êtes. [Le Démon est votre voisin]"
   },
   {
@@ -2101,6 +2104,7 @@
       "Mort"
     ],
     "setup": true,
+    "forbidden": true,
     "ability": "Chaque nuit, les Sbires choisissent qui a la garde du Bébé monstre et “est le Démon”. Chaque nuit*, il se peut qu'un joueur meure. [+1 Sbire]"
   },
   {

--- a/src/store/locale/fr/ui.json
+++ b/src/store/locale/fr/ui.json
@@ -58,6 +58,8 @@
     "background": "Entrez l'URL de l'image de fond",
     "createSession": "Entrez un nom ou numéro de session",
     "sendRoles": "Voulez-vous envoyer les rôles à tous les joueurs ASSIS ?",
+    "sendRolesWithForbidden1": "ATTENTION\nL'un des rôles que vous voulez envoyer est un rôle interdit (",
+    "sendRolesWithForbidden2": ").\nConfirmer l'envoi ?",
     "imageOptIn": "Êtes-vous sûr de vouloir autoriser les images externes ? Un auteur de script mal intentionné pourrait s'en servir pour traquer votre adresse IP.",
     "joinSession": "Entrez le nom ou numéro de la session que vous souhaitez rejoindre",
     "leaveSession": "Êtes-vous sur de vouloir quitter la partie en cours ?",


### PR DESCRIPTION
Certains rôles sont notés comme étant interdits, et comme ne devant jamais être envoyé à un joueur.

Si le Narrateur essaie d'envoyer un de ces rôles (le plus souvent par inattention), il recevra auparavant un message demandant confirmation.