### PR TITLE
Updating Evil Twin's ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Minor rephrasing in the French version (mainly shortening Experimental Townsfolk's abilities)
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1098,7 +1098,7 @@
       "Jumeau"
     ],
     "setup": false,
-    "ability": "Vous & un adversaire savez vos personnages respectifs. Si le bon est exécuté, les mauvais gagnent. Le bien ne peut gagner si vous 2 vivez."
+    "ability": "Vous savez le personnage d'un adversaire, qui vous connaît. Si le bon est exécuté, le mal gagne. Le bien ne peut gagner si vous 2 vivez."
   },
   {
     "id": "witch",


### PR DESCRIPTION
Pour le coup, c'est un petit peu compliqué.

Comme pas mal de rôles, le Jumeau maléfique a à la base été pensé pour une édition précise. Résultat, pour certaines interactions en dehors de cette édition, la description telle qu'elle est écrite peut rentrer en conflit avec l'intention du personnage. Mais même dans ce cas, _The Pandemonium Institute_ ne veut pas changer les descriptions dans les trois éditions de base, car elles ont déjà été vendues.
Mais comme nous, on n'a pas ce problème, on peut modifier les descriptions pour que la lecture stricte matche avec l'intention.

En l'occurrence, la différence arrive si un autre personnage que le Jumeau maléfique a cette capacité. Par exemple, si l'Alchimiste a la capacité du Jumeau maléfique, l'intention est que son jumeau apprenne que le joueur en question est un Jumeau maléfique (et non pas un Alchimiste, comme le voudrait une lecture stricte).



PS : Pour ce qui est de "le mal gagne" au lieu de "les mauvais gagnent", c'est juste pour respecter la limite habituelle de caractères.