### PR TITLE
Correcting French Noble's description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Minor rephrasing in the French version (mainly shortening Experimental Townsfolk's abilities)
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1299,7 +1299,7 @@
       "Connu"
     ],
     "setup": false,
-    "ability": "Vous commencez la partie en connaissant les noms de 3 joueurs, un seul parmi ces 3 joueurs est Mauvais."
+    "ability": "Vous commencez la partie en connaissant 3 joueurs, un seul parmi ces 3 joueurs est mauvais."
   },
   {
     "id": "bountyhunter",


### PR DESCRIPTION
Que ce soit en VO ou dans les autres descriptions VF, il est dit que les personnages apprennent "des joueurs" et pas "des noms de joueurs".