### PR TITLE
Updating French Cult leader's description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Minor rephrasing in the French version (mainly shortening Experimental Townsfolk's abilities)
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -1402,7 +1402,7 @@
     "otherNightReminder": "Si le Gourou change d'équipe, réveillez-le pour l'en informer.",
     "reminders": [],
     "setup": false,
-    "ability": "Chaque nuit, vous rejoignez l'équipe de l'un de vos voisins vivants. Si tous les bons joueurs choisissent de rejoindre votre secte, votre équipe gagne."
+    "ability": "Chaque nuit, vous acquérez l'alignement d'un voisin vivant. Si tous les bons choisissent de rejoindre votre secte, votre équipe gagne."
   },
   {
     "id": "lycanthrope",


### PR DESCRIPTION
D'une part, pour la raccourcir un peu. D'autre part, pour utiliser la formulation habituelle "vous acquérez cet alignement".