### PR TITLE
French Mathematician's reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Updating the text on some reminders (to use official wording and have a french version similar to this official wording)
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -889,7 +889,7 @@
     "otherNight": 86,
     "otherNightReminder": "Indiquez combien de joueurs ont vu leurs capacités dysfonctionner (depuis le matin) à cause d'un autre personnage.",
     "reminders": [
-      "Anormal"
+      "Dysfonctionnement"
     ],
     "setup": false,
     "ability": "Chaque nuit, vous apprenez combien de joueurs ont vu leurs capacités dysfonctionner (depuis le matin) à cause d'un autre personnage."


### PR DESCRIPTION
La VO reprend le même mot que dans la description. Puisqu'on a utilisé une autre traduction pour la description française, il me semble logique de mettre le reminder en accord avec cette description.