### PR TITLE
French Harpy's reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcomming Version
 
-
+- Updating the text on some reminders (to use official wording and have a french version similar to this official wording)
 
 ### Version 4.1.0
 - Correcting a bug with the "give back token" update

--- a/src/store/locale/fr/roles.json
+++ b/src/store/locale/fr/roles.json
@@ -2004,7 +2004,7 @@
     "otherNightReminder": "Réveillez la Harpie. Elle désigne deux joueurs, l'un après l'autre. Réveillez le premier joueur, et lui révéler qu'il est persuadé par la Harpie que le deuxième est mauvais.",
     "reminders": [
       "Persuadé",
-      "2e"
+      "2nd"
     ],
     "setup": false,
     "ability": "Chaque nuit, désignez deux joueurs : demain, le premier sera persuadé que le second est mauvais, ou il se peut que l'un ou les deux meurent."


### PR DESCRIPTION
On a récemment changé la description française, remplaçant "deuxième" par "second". Du coup, il me semble logique de mettre à jour le reminder en conséquence.