### PR TITLE
fix: fixed issue where custom roles are being improperly transformed by the `customRolesStripped` getter

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -211,7 +211,7 @@ const initializeStore = async () => {
               if (strippedProps.includes(prop as typeof strippedProps[number])) continue;
               const value = roleObj[prop];
               if (customKeys.includes(prop) && value !== customObj[prop]) {
-                strippedRole[String(customKeys.indexOf(prop))] = value;
+                strippedRole[String(customKeys[customKeys.indexOf(prop)])] = value;
               }
             }
             customRoles.push(strippedRole);


### PR DESCRIPTION
There's an issue with the store's `customRolesStripped` getters function. When building the `strippedRole` object, the objects props are being set to `customKeys.indexOf(prop)` rather than `customKeys[customKeys.indexOf(prop)]`. This results in an object like this (note the string integer keys):

<img width="340" height="146" alt="Screenshot 2025-09-13 at 10 35 51 PM" src="https://github.com/user-attachments/assets/abdb01b3-cdae-44bb-8bc8-a13e201f7160" />

With the fix in place, the store returns the correct object:

<img width="342" height="179" alt="Screenshot 2025-09-13 at 10 36 19 PM" src="https://github.com/user-attachments/assets/34bb688e-c88e-4328-90a6-9d66b2111e1d" />

---

This is a pretty impactful bug, as it causes networked games that use custom roles to break, since this is the object sent to player clients to update their edition data.